### PR TITLE
Add Inline JSDoc types

### DIFF
--- a/packages/rpc/src/client.ts
+++ b/packages/rpc/src/client.ts
@@ -25,6 +25,11 @@ import type {
 	RouterRecord,
 } from "./types";
 
+/**
+ * Extracts the response type from an endpoint definition
+ * Maps endpoint output, format, and status to a ClientResponse type
+ * @template T - The endpoint type to extract response from
+ */
 type ClientResponseOfEndpoint<T extends Endpoint = Endpoint> = T extends {
 	output: infer O;
 	outputFormat: infer F;
@@ -37,6 +42,11 @@ type ClientResponseOfEndpoint<T extends Endpoint = Endpoint> = T extends {
 		>
 	: never;
 
+/**
+ * Generates a client interface for making requests to API endpoints
+ * Provides type-safe methods for HTTP requests and WebSocket connections
+ * @template S - Schema type defining the available endpoints
+ */
 export type ClientRequest<S extends Schema> = {
 	[M in keyof S]: S[M] extends Endpoint & { input: infer R }
 		? undefined extends R
@@ -50,6 +60,11 @@ export type ClientRequest<S extends Schema> = {
 				) => Promise<ClientResponseOfEndpoint<S[M]>>
 		: never;
 } & {
+	/**
+	 * Generates a URL for the endpoint with optional parameters
+	 * @param arg - Optional parameters including query params and path params
+	 * @returns URL object for the endpoint
+	 */
 	$url: (
 		arg?: S[keyof S] extends { input: infer R }
 			? R extends { param: infer P }
@@ -68,13 +83,26 @@ export type ClientRequest<S extends Schema> = {
 				outgoing: infer Outgoing;
 			}
 			? {
+					/**
+					 * Creates a WebSocket connection to the endpoint
+					 * @param args - Optional connection arguments
+					 * @returns ClientSocket for real-time communication
+					 */
 					$ws: (args?: I) => ClientSocket<Incoming & SystemEvents, Outgoing>;
 				}
 			: Record<string, never>
 		: void);
 
+/**
+ * Unwraps a RouterSchema to extract the underlying route structure
+ * @template T - RouterSchema type to unwrap
+ */
 export type UnwrapRouterSchema<T> = T extends RouterSchema<infer R> ? R : never;
 
+/**
+ * Infers the schema type from a Router instance
+ * @template T - Router type to infer schema from
+ */
 export type InferRouter<T extends Router<RouterRecord, Env>> = T extends Router<
 	infer P,
 	Env
@@ -82,6 +110,12 @@ export type InferRouter<T extends Router<RouterRecord, Env>> = T extends Router<
 	? RouterSchema<P>
 	: never;
 
+/**
+ * Maps route procedures to their corresponding client request interfaces
+ * Handles both individual operations and nested route structures
+ * @template P - Procedure/route structure to map
+ * @template E - Environment type
+ */
 type ClientRouteMapping<P, E extends Env> = {
 	[K in keyof P]: P[K] extends OperationType<unknown, Response, E>
 		? ClientRequest<OperationSchema<P[K], E>>
@@ -90,6 +124,11 @@ type ClientRouteMapping<P, E extends Env> = {
 			: never;
 };
 
+/**
+ * Generates a complete client interface for a Router or Router factory function
+ * Provides type-safe access to all routes with proper method signatures
+ * @template T - Router instance or Router factory function type
+ */
 export type Client<
 	T extends
 		| Router<RouterRecord, InferRouterEnv<T>>
@@ -112,6 +151,12 @@ export type Client<
 		: never
 	: never;
 
+/**
+ * Extracts input or output types from router operations
+ * Used internally for type inference of router I/O schemas
+ * @template T - Router or Router factory type
+ * @template IOType - Whether to extract "input" or "output" types
+ */
 type OperationIO<
 	T extends
 		| Router<RouterRecord, Env>
@@ -150,17 +195,37 @@ type OperationIO<
 		: never
 	: never;
 
+/**
+ * Infers all output types from router operations
+ * Useful for understanding what data types the router returns
+ * @template T - Router type to extract outputs from
+ */
 export type InferRouterOutputs<T extends Router<RouterRecord, Env>> =
 	OperationIO<T, "output">;
+
+/**
+ * Infers all input types from router operations
+ * Useful for understanding what data types the router accepts
+ * @template T - Router type to extract inputs from
+ */
 export type InferRouterInputs<T extends Router<RouterRecord, Env>> =
 	OperationIO<T, "input">;
 
+/**
+ * Configuration options for the API client
+ * Extends Hono's ClientRequestOptions with additional settings
+ */
 export interface ClientConfig extends ClientRequestOptions {
+	/** Base URL for all API requests (required) */
 	baseUrl: string;
+	/** Credential policy for requests, defaults to "include" */
 	credentials?: RequestCredentials;
 }
 
-// Type for the serialized data structure
+/**
+ * Type definition for serializable values that can be sent over the network
+ * Includes primitives, arrays, and objects with serializable properties
+ */
 type SerializableValue =
 	| string
 	| number
@@ -170,19 +235,65 @@ type SerializableValue =
 	| SerializableValue[]
 	| { [key: string]: SerializableValue };
 
-// Type for HTTP method arguments
+/**
+ * Arguments structure for HTTP method calls
+ * @template T - Type of data being sent, defaults to unknown
+ */
 type HttpMethodArgs<T = unknown> = [data?: T, options?: ClientRequestOptions];
 
-// Improved proxy target interface
+/**
+ * Interface for proxy target objects used in client method delegation
+ * Defines the structure for HTTP methods and WebSocket connections
+ */
 interface ProxyTarget {
+	/** GET request method */
 	$get?: (...args: HttpMethodArgs) => Promise<Response>;
+	/** POST request method */
 	$post?: (...args: HttpMethodArgs) => Promise<Response>;
+	/** WebSocket connection method */
 	$ws?: () => ClientSocket<SystemEvents, Record<string, unknown>>;
+	/** Additional dynamic properties */
 	[key: string]: unknown;
 }
 
+/**
+ * Infers the environment type from a Router instance
+ * @template T - Router type to extract environment from
+ */
 type InferRouterEnv<T> = T extends Router<RouterRecord, infer E> ? E : never;
 
+/**
+ * Creates a type-safe HTTP client for communicating with JSandy routers
+ * Provides automatic serialization, error handling, and type inference
+ *
+ * @template T - Router type that defines the API structure
+ * @param options - Client configuration options including base URL
+ * @returns Type-safe client with methods matching the router's API
+ *
+ * @example
+ * ```typescript
+ * // Create client for a specific router
+ * const client = createClient<typeof myRouter>({
+ *   baseUrl: 'https://api.example.com'
+ * });
+ *
+ * // Type-safe API calls
+ * const user = await client.users.getUser({ id: '123' });
+ * const result = await client.posts.createPost({ title: 'Hello', content: '...' });
+ *
+ * // WebSocket connections
+ * const socket = client.chat.$ws();
+ * socket.emit('message', { text: 'Hello!' });
+ * ```
+ *
+ * Features:
+ * - **Type Safety**: Full TypeScript inference for all API methods
+ * - **SuperJSON Support**: Automatic serialization of complex objects
+ * - **Error Handling**: Converts HTTP errors to HTTPException instances
+ * - **WebSocket Support**: Type-safe real-time communication
+ * - **Credential Management**: Configurable authentication handling
+ * - **URL Generation**: Helper methods for constructing endpoint URLs
+ */
 export const createClient = <T extends Router<RouterRecord, InferRouterEnv<T>>>(
 	options?: ClientConfig,
 ): UnionToIntersection<Client<T>> => {
@@ -192,15 +303,22 @@ export const createClient = <T extends Router<RouterRecord, InferRouterEnv<T>>>(
 		...opts
 	} = options ?? ({} as ClientConfig);
 
+	// Validate base URL format
 	if (baseUrl !== "" && !baseUrl.startsWith("http")) {
 		throw new Error("baseUrl must start with http:// or https://");
 	}
 
+	/**
+	 * Enhanced fetch function with automatic error handling and SuperJSON support
+	 * @param input - Request URL or Request object
+	 * @param init - Request initialization options
+	 * @returns Promise resolving to enhanced Response object
+	 */
 	const jfetch = async (
 		input: RequestInfo | URL,
 		init?: RequestInit,
 	): Promise<Response> => {
-		// remove baseUrl from input if already included, for example during SSR
+		// Remove baseUrl from input if already included (useful during SSR)
 		const inputPath = input.toString().replace(baseUrl, "");
 		const targetUrl = baseUrl + inputPath;
 
@@ -210,6 +328,7 @@ export const createClient = <T extends Router<RouterRecord, InferRouterEnv<T>>>(
 			cache: "no-store",
 		});
 
+		// Convert HTTP errors to exceptions
 		if (!res.ok) {
 			const message = await res.text();
 			throw new HTTPException(res.status as ContentfulStatusCode, {
@@ -217,10 +336,12 @@ export const createClient = <T extends Router<RouterRecord, InferRouterEnv<T>>>(
 			});
 		}
 
+		// Override json() method to support SuperJSON
 		res.json = () => parseJsonResponse(res);
 		return res;
 	};
 
+	// Create base Hono client
 	const baseClient = hc(baseUrl, {
 		...opts,
 		fetch: opts.fetch || jfetch,
@@ -229,6 +350,12 @@ export const createClient = <T extends Router<RouterRecord, InferRouterEnv<T>>>(
 	return createProxy(baseClient, baseUrl) as UnionToIntersection<Client<T>>;
 };
 
+/**
+ * Parses JSON responses with SuperJSON support
+ * Automatically detects and deserializes SuperJSON-encoded responses
+ * @param response - HTTP response to parse
+ * @returns Parsed response data with complex objects restored
+ */
 const parseJsonResponse = async (response: Response): Promise<unknown> => {
 	const text = await response.text();
 	const isSuperjson = response.headers.get("x-is-superjson") === "true";
@@ -241,6 +368,12 @@ const parseJsonResponse = async (response: Response): Promise<unknown> => {
 	}
 };
 
+/**
+ * Serializes data using SuperJSON for transmission
+ * Converts object properties to SuperJSON-encoded strings
+ * @param data - Data object to serialize
+ * @returns Record with SuperJSON-serialized string values
+ */
 function serializeWithSuperJSON(data: unknown): Record<string, string> {
 	if (typeof data !== "object" || data === null) {
 		return {};
@@ -255,6 +388,22 @@ function serializeWithSuperJSON(data: unknown): Record<string, string> {
 	);
 }
 
+/**
+ * Creates a dynamic proxy for client method delegation
+ * Enables type-safe access to nested routes and automatic request handling
+ *
+ * @param baseClient - Base client instance to proxy requests through
+ * @param baseUrl - Base URL for constructing request URLs
+ * @param path - Current path segments for nested route handling
+ * @returns Proxy object with dynamic method resolution
+ *
+ * The proxy handles:
+ * - **$get**: GET requests with query parameter serialization
+ * - **$post**: POST requests with body serialization
+ * - **$url**: URL generation for endpoints
+ * - **$ws**: WebSocket connection creation
+ * - **Dynamic nesting**: Automatic proxy chaining for nested routes
+ */
 function createProxy(
 	baseClient: ProxyTarget,
 	baseUrl: string,
@@ -265,6 +414,7 @@ function createProxy(
 			if (typeof prop === "string") {
 				const routePath = [...path, prop];
 
+				// Handle GET requests with query parameter serialization
 				if (prop === "$get") {
 					return async (...args: HttpMethodArgs) => {
 						const [data, options] = args;
@@ -273,6 +423,7 @@ function createProxy(
 					};
 				}
 
+				// Handle POST requests with body serialization
 				if (prop === "$post") {
 					return async (...args: HttpMethodArgs) => {
 						const [data, options] = args;
@@ -281,12 +432,14 @@ function createProxy(
 					};
 				}
 
+				// Handle URL generation for endpoints
 				if (prop === "$url") {
 					return (args?: { query: Record<string, SerializableValue> }): URL => {
 						const endpointPath = `/${routePath.slice(0, -1).join("/")}`;
 						const normalizedPath = endpointPath.replace(baseUrl, "");
 						const url = new URL(baseUrl + normalizedPath);
 
+						// Add query parameters if provided
 						if (args?.query) {
 							for (const [key, value] of Object.entries(args.query)) {
 								if (value !== null && value !== undefined) {
@@ -299,25 +452,27 @@ function createProxy(
 					};
 				}
 
+				// Handle WebSocket connection creation
 				if (prop === "$ws") {
 					return (): ClientSocket<SystemEvents, Record<string, unknown>> => {
 						const endpointPath = `/${routePath.slice(0, -1).join("/")}`;
 						const normalizedPath = endpointPath.replace(baseUrl, "");
 						const url = new URL(baseUrl + normalizedPath);
 
-						// Change protocol to ws:// or wss:// depending on if https or http
+						// Convert HTTP protocol to WebSocket protocol
 						url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
 
 						return new ClientSocket(url);
 					};
 				}
 
+				// Handle nested route access
 				const nestedTarget = target[prop] as ProxyTarget | undefined;
 				if (nestedTarget) {
 					return createProxy(nestedTarget, baseUrl, routePath);
 				}
 
-				// Return empty object for unknown properties to maintain proxy chain
+				// Return empty proxy for unknown properties to maintain proxy chain
 				return createProxy({}, baseUrl, routePath);
 			}
 

--- a/packages/rpc/src/j.ts
+++ b/packages/rpc/src/j.ts
@@ -1,5 +1,3 @@
-// j.ts - Updated router function signature
-
 import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import type { Env, HTTPResponseError, MiddlewareHandler } from "hono/types";

--- a/packages/rpc/src/j.ts
+++ b/packages/rpc/src/j.ts
@@ -10,6 +10,19 @@ import type { MiddlewareFunction } from "./types";
 
 /**
  * Adapts a Hono middleware to be compatible with the type-safe middleware format
+ * Converts standard Hono middleware handlers to JSandy's middleware function interface
+ *
+ * @template E - Environment type extending Hono's Env, defaults to Env
+ * @param honoMiddleware - Standard Hono middleware handler function
+ * @returns JSandy-compatible middleware function with type-safe context handling
+ *
+ * @example
+ * ```typescript
+ * import { logger } from 'hono/logger';
+ *
+ * const loggerMiddleware = fromHono(logger());
+ * const procedure = jsandy.init().procedure.use(loggerMiddleware);
+ * ```
  */
 export function fromHono<E extends Env = Env>(
 	honoMiddleware: MiddlewareHandler<E>,
@@ -21,33 +34,136 @@ export function fromHono<E extends Env = Env>(
 	};
 }
 
+/**
+ * Main JSandy framework class providing type-safe API development tools
+ * Offers a fluent interface for building APIs with automatic validation, middleware chaining,
+ * and WebSocket support while maintaining full TypeScript type safety
+ */
 class JSandy {
+	/**
+	 * Initializes a new JSandy instance with environment-specific typing
+	 * Returns a toolkit for building type-safe APIs with routers, procedures, and middleware
+	 *
+	 * @template E - Environment type extending Hono's Env, defaults to Env
+	 * @returns Object containing all JSandy development tools and utilities
+	 *
+	 * @example
+	 * ```typescript
+	 * // Basic initialization
+	 * const { router, procedure, middleware } = jsandy.init();
+	 *
+	 * // With custom environment type
+	 * interface MyEnv {
+	 *   Variables: { user: User };
+	 *   Bindings: { DATABASE_URL: string };
+	 * }
+	 * const api = jsandy.init<MyEnv>();
+	 * ```
+	 */
 	init<E extends Env = Env>() {
 		return {
+			/**
+			 * Creates a new Router instance with type-safe procedure definitions
+			 * @template T - Record type of procedures and nested routes
+			 * @param procedures - Optional initial procedures to register, defaults to empty object
+			 * @returns New Router instance with the specified procedures
+			 *
+			 * @example
+			 * ```typescript
+			 * const userRouter = router({
+			 *   getUser: procedure.input(getUserSchema).get(getUserHandler),
+			 *   updateUser: procedure.input(updateUserSchema).post(updateUserHandler)
+			 * });
+			 * ```
+			 */
 			router: <T extends Record<string, unknown>>(
 				procedures: T = {} as T,
 			): Router<T, E> => {
 				return new Router(procedures);
 			},
+
+			/** Router merging utility for combining multiple routers */
 			mergeRouters,
+
+			/**
+			 * Type-safe middleware function wrapper for enhanced type inference
+			 * Provides better TypeScript support for custom middleware development
+			 *
+			 * @template T - Context type for the middleware, defaults to Record<string, unknown>
+			 * @template R - Return type of the middleware, defaults to void
+			 * @param middleware - Middleware function to wrap with type safety
+			 * @returns The same middleware function with enhanced type information
+			 *
+			 * @example
+			 * ```typescript
+			 * const authMiddleware = middleware(async ({ c, next, ctx }) => {
+			 *   const token = c.req.header('Authorization');
+			 *   if (!token) throw new HTTPException(401);
+			 *
+			 *   const user = await validateToken(token);
+			 *   await next({ user }); // Type-safe context passing
+			 * });
+			 * ```
+			 */
 			middleware: <T = Record<string, unknown>, R = void>(
 				middleware: MiddlewareFunction<T, R, E>,
 			): MiddlewareFunction<T, R, E> => middleware,
+
+			/** Hono middleware adapter utility */
 			fromHono,
+
+			/** Pre-configured Procedure instance for building endpoints */
 			procedure: new Procedure<E>(),
+
+			/**
+			 * Default configurations and utilities for common API patterns
+			 */
 			defaults: {
+				/**
+				 * Pre-configured CORS middleware with SuperJSON support
+				 * Allows SuperJSON headers and enables cross-origin requests with credentials
+				 *
+				 * Configuration:
+				 * - Allows 'x-is-superjson' and 'Content-Type' headers
+				 * - Exposes 'x-is-superjson' header to clients
+				 * - Permits requests from any origin
+				 * - Enables credential sharing
+				 */
 				cors: cors({
 					allowHeaders: ["x-is-superjson", "Content-Type"],
 					exposeHeaders: ["x-is-superjson"],
 					origin: (origin) => origin,
 					credentials: true,
 				}),
+
+				/**
+				 * Comprehensive error handler for common API error scenarios
+				 * Automatically converts various error types into appropriate HTTP responses
+				 *
+				 * Handles:
+				 * - **HTTPException**: Returns the exception's built-in response
+				 * - **ZodError**: Converts validation errors to 422 status with details
+				 * - **HTTP-like errors**: Objects with status property become HTTP responses
+				 * - **Unknown errors**: Fallback to 500 status with generic message
+				 *
+				 * @param err - Error object or HTTP response error to handle
+				 * @returns HTTP Response with appropriate status code and error message
+				 *
+				 * @example
+				 * ```typescript
+				 * const api = new Hono();
+				 * api.onError(jsandy.init().defaults.errorHandler);
+				 * ```
+				 */
 				errorHandler: (err: Error | HTTPResponseError) => {
 					console.error("[API Error]", err);
 
+					// Handle Hono HTTP exceptions
 					if (err instanceof HTTPException) {
 						return err.getResponse();
 					}
+
+					// Handle Zod validation errors
 					if (err instanceof ZodError) {
 						const httpError = new HTTPException(422, {
 							message: "Validation error",
@@ -56,6 +172,8 @@ class JSandy {
 
 						return httpError.getResponse();
 					}
+
+					// Handle objects with HTTP status codes
 					if (
 						err &&
 						typeof err === "object" &&
@@ -72,6 +190,8 @@ class JSandy {
 
 						return httpError.getResponse();
 					}
+
+					// Fallback for unknown errors
 					const httpError = new HTTPException(500, {
 						message:
 							"An unexpected error occurred. Check server logs for details.",
@@ -85,4 +205,19 @@ class JSandy {
 	}
 }
 
+/**
+ * Main JSandy framework instance
+ * Entry point for all JSandy API development tools and utilities
+ *
+ * @example
+ * ```typescript
+ * import { jsandy } from './jsandy';
+ *
+ * const { router, procedure } = jsandy.init();
+ *
+ * const api = router({
+ *   hello: procedure.get(() => ({ message: 'Hello World!' }))
+ * });
+ * ```
+ */
 export const jsandy = new JSandy();

--- a/packages/rpc/src/procedure.ts
+++ b/packages/rpc/src/procedure.ts
@@ -15,6 +15,17 @@ import type {
 	WebSocketHandler,
 	WebSocketOperation,
 } from "./types";
+
+/**
+ * Procedure class for building type-safe API endpoints with middleware chaining
+ * Provides a fluent interface for configuring input validation, middleware, and handlers
+ *
+ * @template E - Environment type extending Hono's Env, defaults to Env
+ * @template Ctx - Context object type accumulated from middleware, defaults to Record<string, unknown>
+ * @template InputSchema - Zod schema type for input validation, defaults to void
+ * @template Incoming - Zod schema type for incoming WebSocket messages, defaults to void
+ * @template Outgoing - Zod schema type for outgoing WebSocket messages, defaults to void
+ */
 export class Procedure<
 	E extends Env = Env,
 	Ctx = Record<string, unknown>,
@@ -22,15 +33,33 @@ export class Procedure<
 	Incoming extends ZodObject | void = void,
 	Outgoing extends ZodObject | void = void,
 > {
+	/** Array of middleware functions to execute in sequence */
 	private readonly middlewares: MiddlewareFunction<Ctx, void, E>[] = [];
+
+	/** Zod schema for validating input parameters */
 	private readonly inputSchema?: InputSchema;
+
+	/** Zod schema for validating incoming WebSocket messages */
 	private readonly incomingSchema?: Incoming;
+
+	/** Zod schema for validating outgoing WebSocket messages */
 	private readonly outgoingSchema?: Outgoing;
 
+	/**
+	 * Built-in middleware that adds SuperJSON serialization support to the context
+	 * Automatically serializes complex JavaScript objects (dates, sets, maps, etc.)
+	 */
 	private superjsonMiddleware: MiddlewareFunction<Ctx, void, E> =
 		async function superjsonMiddleware({ c, next }) {
 			type JSONRespond = typeof c.json;
 
+			/**
+			 * Adds superjson method to context for enhanced serialization
+			 * @template T - Type of data to serialize
+			 * @param data - Data to serialize using SuperJSON
+			 * @param status - Optional HTTP status code
+			 * @returns Response with SuperJSON serialized data
+			 */
 			c.superjson = (<T>(data: T, status?: StatusCode): Response => {
 				const serialized = superjson.stringify(data);
 
@@ -43,6 +72,14 @@ export class Procedure<
 			await next();
 		};
 
+	/**
+	 * Creates a new Procedure instance with optional middleware and schemas
+	 *
+	 * @param middlewares - Array of middleware functions to apply, defaults to empty array
+	 * @param inputSchema - Optional Zod schema for input validation
+	 * @param incomingSchema - Optional Zod schema for incoming WebSocket message validation
+	 * @param outgoingSchema - Optional Zod schema for outgoing WebSocket message validation
+	 */
 	constructor(
 		middlewares: MiddlewareFunction<Ctx, void, E>[] = [],
 		inputSchema?: InputSchema,
@@ -54,13 +91,19 @@ export class Procedure<
 		this.incomingSchema = incomingSchema;
 		this.outgoingSchema = outgoingSchema;
 
+		// Ensure SuperJSON middleware is always included
 		if (!this.middlewares.some((mw) => mw.name === "superjsonMiddleware")) {
 			this.middlewares.push(this.superjsonMiddleware);
 		}
 	}
 
 	/**
-	 * Validates incoming WebSocket messages using a Zod schema.
+	 * Sets the schema for validating incoming WebSocket messages
+	 * Creates a new Procedure instance with the updated incoming schema
+	 *
+	 * @template Schema - Zod object schema type for incoming messages
+	 * @param schema - Zod schema to validate incoming WebSocket messages
+	 * @returns New Procedure instance with incoming schema configured
 	 */
 	incoming<Schema extends ZodObject>(schema: Schema) {
 		return new Procedure<E, Ctx, InputSchema, Schema, Outgoing>(
@@ -72,7 +115,12 @@ export class Procedure<
 	}
 
 	/**
-	 * Validates outgoing WebSocket messages using a Zod schema.
+	 * Sets the schema for validating outgoing WebSocket messages
+	 * Creates a new Procedure instance with the updated outgoing schema
+	 *
+	 * @template Schema - Zod object schema type for outgoing messages
+	 * @param schema - Zod schema to validate outgoing WebSocket messages
+	 * @returns New Procedure instance with outgoing schema configured
 	 */
 	outgoing<Schema extends ZodObject>(schema: Schema) {
 		return new Procedure<E, Ctx, InputSchema, Incoming, Schema>(
@@ -84,7 +132,12 @@ export class Procedure<
 	}
 
 	/**
-	 * Validates input parameters using a Zod schema.
+	 * Sets the schema for validating input parameters (query params for GET, body for POST)
+	 * Creates a new Procedure instance with the updated input schema
+	 *
+	 * @template Schema - Zod object schema type for input validation
+	 * @param schema - Zod schema to validate input parameters
+	 * @returns New Procedure instance with input schema configured
 	 */
 	input<Schema extends ZodObject>(schema: Schema) {
 		return new Procedure<E, Ctx, Schema, Incoming, Outgoing>(
@@ -96,7 +149,13 @@ export class Procedure<
 	}
 
 	/**
-	 * Adds a middleware function to the procedure chain.
+	 * Adds a middleware function to the procedure chain
+	 * Middleware functions are executed in the order they are added
+	 *
+	 * @template T - Type of additional context data the middleware provides
+	 * @template Return - Return type of the middleware function, defaults to void
+	 * @param handler - Middleware function to add to the chain
+	 * @returns New Procedure instance with the middleware added and updated context type
 	 */
 	use<T extends Record<string, unknown>, Return = void>(
 		handler: MiddlewareFunction<Ctx, Return, E>,
@@ -110,6 +169,16 @@ export class Procedure<
 		);
 	}
 
+	/**
+	 * Creates a GET operation with the configured middleware and schemas
+	 *
+	 * @template Return - Return type of the handler function
+	 * @param handler - Function to handle GET requests
+	 * @param handler.ctx - Context object accumulated from middleware
+	 * @param handler.c - Hono context with SuperJSON capabilities
+	 * @param handler.input - Validated input data based on input schema
+	 * @returns GetOperation configuration object
+	 */
 	get<Return extends OptionalPromise<ResponseType<unknown>>>(
 		handler: (params: {
 			ctx: Ctx;
@@ -140,6 +209,14 @@ export class Procedure<
 		return operation;
 	}
 
+	/**
+	 * Alias for the get() method - creates a GET operation (query endpoint)
+	 * Semantically indicates this endpoint is for querying data
+	 *
+	 * @template Return - Return type of the handler function
+	 * @param handler - Function to handle query requests
+	 * @returns GetOperation configuration object
+	 */
 	query<Return extends OptionalPromise<ResponseType<unknown>>>(
 		handler: (params: {
 			ctx: Ctx;
@@ -150,6 +227,16 @@ export class Procedure<
 		return this.get(handler);
 	}
 
+	/**
+	 * Creates a POST operation with the configured middleware and schemas
+	 *
+	 * @template Return - Return type of the handler function
+	 * @param handler - Function to handle POST requests
+	 * @param handler.ctx - Context object accumulated from middleware
+	 * @param handler.c - Hono context with SuperJSON capabilities
+	 * @param handler.input - Validated input data based on input schema
+	 * @returns PostOperation configuration object
+	 */
 	post<Return extends OptionalPromise<ResponseType<unknown>>>(
 		handler: (params: {
 			ctx: Ctx;
@@ -180,6 +267,14 @@ export class Procedure<
 		return operation;
 	}
 
+	/**
+	 * Alias for the post() method - creates a POST operation (mutation endpoint)
+	 * Semantically indicates this endpoint is for mutating/changing data
+	 *
+	 * @template Return - Return type of the handler function
+	 * @param handler - Function to handle mutation requests
+	 * @returns PostOperation configuration object
+	 */
 	mutation<Return extends OptionalPromise<ResponseType<unknown>>>(
 		handler: (params: {
 			ctx: Ctx;
@@ -190,6 +285,16 @@ export class Procedure<
 		return this.post(handler);
 	}
 
+	/**
+	 * Creates a WebSocket operation with the configured middleware and schemas
+	 * Enables real-time bidirectional communication with message validation
+	 *
+	 * @param handler - Function to handle WebSocket connections
+	 * @param handler.io - IO interface for WebSocket communication with validated outgoing data
+	 * @param handler.c - Hono context with SuperJSON capabilities
+	 * @param handler.ctx - Context object accumulated from middleware
+	 * @returns WebSocketOperation configuration object with incoming/outgoing schemas
+	 */
 	ws(
 		handler: (params: {
 			io: IO<InferWebSocketData<Outgoing>>;

--- a/packages/rpc/src/schemas.ts
+++ b/packages/rpc/src/schemas.ts
@@ -1,9 +1,41 @@
 import type { z } from "zod/v4";
 
+/**
+ * Utility type that performs strict equality comparison between two types
+ * Returns true only if T and U are exactly the same type (bidirectional extends check)
+ * @template T - First type to compare
+ * @template U - Second type to compare
+ */
 type StrictEqual<T, U> = T extends U ? (U extends T ? true : false) : false;
 
+/**
+ * Creates a type-safe schema builder that ensures the Zod schema exactly matches the target type T
+ * This function provides compile-time type safety by enforcing that the schema's inferred type
+ * is strictly equal to the specified target type
+ *
+ * @template T - The target type that the schema must match exactly
+ * @returns A function that accepts a Zod schema and validates it matches type T
+ *
+ * @example
+ * ```typescript
+ * interface User {
+ *   name: string;
+ *   age: number;
+ * }
+ *
+ * const userSchemaBuilder = createSchema<User>();
+ * const userSchema = userSchemaBuilder(z.object({
+ *   name: z.string(),
+ *   age: z.number()
+ * })); // ✅ Valid - schema matches User interface exactly
+ * ```
+ */
 export function createSchema<T extends Record<string, unknown>>() {
 	return <U extends z.ZodRawShape>(
+		/**
+		 * Zod object schema that must exactly match the target type T
+		 * @param schema - The Zod schema to validate against type T
+		 */
 		schema: StrictEqual<T, z.infer<z.ZodObject<U>>> extends true
 			? z.ZodObject<U>
 			: never,
@@ -12,8 +44,29 @@ export function createSchema<T extends Record<string, unknown>>() {
 	};
 }
 
+/**
+ * Creates a type-safe enum schema builder for Zod enums with string values
+ * This function ensures the enum schema contains values of the specified string type T
+ *
+ * @template T - The string literal type that enum values must extend
+ * @returns A function that accepts a Zod enum schema and validates its value types
+ *
+ * @example
+ * ```typescript
+ * type Status = "active" | "inactive" | "pending";
+ *
+ * const statusSchemaBuilder = createEnumSchema<Status>();
+ * const statusSchema = statusSchemaBuilder(
+ *   z.enum(["active", "inactive", "pending"])
+ * ); // ✅ Valid - all enum values are of type Status
+ * ```
+ */
 export function createEnumSchema<T extends string>() {
 	return <const U extends Readonly<Record<string, T>>>(
+		/**
+		 * Zod enum schema with values that must be of type T
+		 * @param schema - The Zod enum schema to return
+		 */
 		schema: z.ZodEnum<U>,
 	): z.ZodEnum<U> => schema;
 }

--- a/packages/rpc/src/sockets/event-emitter.ts
+++ b/packages/rpc/src/sockets/event-emitter.ts
@@ -2,27 +2,90 @@ import { ZodError, type ZodObject, treeifyError, type z } from "zod/v4";
 import type { OptionalPromise } from "../types";
 import { logger } from "./logger";
 
+/**
+ * Schema type that can be either a ZodObject for validation or void for no validation
+ */
 type Schema = ZodObject | void;
+
+/**
+ * Infers the TypeScript type from a schema definition
+ * @template T - The schema type to infer from
+ * @returns The inferred TypeScript type, undefined for void schemas, never for invalid schemas
+ */
 export type InferSchemaType<T> = T extends ZodObject
 	? z.infer<T>
 	: T extends void
 		? undefined
 		: never;
+
+/**
+ * Event handler function type that processes validated event data
+ * @param data - Validated event data matching the schema type
+ * @returns Any value (return value is ignored)
+ */
 export type EventHandler = (data: InferSchemaType<Schema>) => unknown;
 
+/**
+ * Configuration interface for WebSocket message schemas
+ */
 interface SchemaConfig {
+	/** Schema for validating incoming messages from clients */
 	incomingSchema: Schema;
+	/** Schema for validating outgoing messages to clients */
 	outgoingSchema: Schema;
 }
 
+/**
+ * Type-safe WebSocket event emitter with automatic schema validation
+ * Provides a robust event system for WebSocket communication with built-in validation,
+ * error handling, and logging capabilities
+ *
+ * Features:
+ * - **Schema Validation**: Automatic validation of incoming and outgoing messages
+ * - **Type Safety**: Full TypeScript inference for event data
+ * - **Error Handling**: Comprehensive error logging and recovery
+ * - **Event Management**: Register, unregister, and trigger event handlers
+ * - **Connection State**: Automatic WebSocket state checking
+ */
 export class EventEmitter {
+	/** Map storing event handlers organized by event name */
 	eventHandlers = new Map<string, EventHandler[]>();
 
+	/** WebSocket connection instance */
 	ws: WebSocket;
 
+	/** Zod schema for validating incoming messages */
 	incomingSchema: Schema;
+
+	/** Zod schema for validating outgoing messages */
 	outgoingSchema: Schema;
 
+	/**
+	 * Creates a new EventEmitter instance with WebSocket and schema configuration
+	 *
+	 * @param ws - WebSocket connection to manage
+	 * @param schemas - Schema configuration for message validation
+	 * @param schemas.incomingSchema - Schema for validating incoming messages
+	 * @param schemas.outgoingSchema - Schema for validating outgoing messages
+	 *
+	 * @example
+	 * ```typescript
+	 * const incomingSchema = z.object({
+	 *   type: z.string(),
+	 *   payload: z.any()
+	 * });
+	 *
+	 * const outgoingSchema = z.object({
+	 *   message: z.string(),
+	 *   timestamp: z.date()
+	 * });
+	 *
+	 * const emitter = new EventEmitter(websocket, {
+	 *   incomingSchema,
+	 *   outgoingSchema
+	 * });
+	 * ```
+	 */
 	constructor(ws: WebSocket, schemas: SchemaConfig) {
 		const { incomingSchema, outgoingSchema } = schemas;
 
@@ -31,12 +94,41 @@ export class EventEmitter {
 		this.outgoingSchema = outgoingSchema;
 	}
 
+	/**
+	 * Emits an event with data through the WebSocket connection
+	 * Validates outgoing data against the schema before sending
+	 *
+	 * @param event - Event name to emit
+	 * @param data - Event data to send (will be validated against outgoingSchema)
+	 * @returns Promise<boolean> or boolean indicating if the message was sent successfully
+	 *
+	 * @example
+	 * ```typescript
+	 * // Emit a chat message
+	 * const success = emitter.emit('message', {
+	 *   text: 'Hello World!',
+	 *   timestamp: new Date()
+	 * });
+	 *
+	 * if (!success) {
+	 *   console.log('Failed to send message');
+	 * }
+	 * ```
+	 *
+	 * Behavior:
+	 * - **Connection Check**: Verifies WebSocket is in OPEN state
+	 * - **Schema Validation**: Validates data against outgoingSchema if present
+	 * - **Error Handling**: Logs validation errors and returns false on failure
+	 * - **Message Format**: Sends data as JSON array: [eventName, data]
+	 */
 	emit(event: string, data: unknown): OptionalPromise<boolean> {
+		// Check WebSocket connection state
 		if (this.ws.readyState !== WebSocket.OPEN) {
 			logger.warn("WebSocket is not in OPEN state. Message not sent.");
 			return false;
 		}
 
+		// Validate outgoing data if schema is configured
 		if (this.outgoingSchema) {
 			try {
 				this.outgoingSchema.parse(data);
@@ -46,10 +138,21 @@ export class EventEmitter {
 			}
 		}
 
+		// Send message as JSON array
 		this.ws.send(JSON.stringify([event, data]));
 		return true;
 	}
 
+	/**
+	 * Handles schema validation errors for outgoing messages
+	 * Provides detailed error logging with formatted error trees
+	 *
+	 * @param event - Event name that failed validation
+	 * @param data - Data that failed validation
+	 * @param err - Error that occurred during validation
+	 *
+	 * @private
+	 */
 	handleSchemaMismatch(event: string, data: unknown, err: unknown) {
 		if (err instanceof ZodError) {
 			logger.error(`Invalid outgoing event data for "${event}":`, {
@@ -61,9 +164,31 @@ export class EventEmitter {
 		}
 	}
 
+	/**
+	 * Processes incoming events by validating data and executing registered handlers
+	 * Validates incoming data against schema and calls all registered event handlers
+	 *
+	 * @param eventName - Name of the event to handle
+	 * @param data - Event data to validate and pass to handlers
+	 *
+	 * @throws {Error} If one or more handlers fail during execution
+	 *
+	 * @example
+	 * ```typescript
+	 * // This is typically called internally when messages are received
+	 * emitter.handleEvent('userJoined', { userId: '123', name: 'Alice' });
+	 * ```
+	 *
+	 * Process:
+	 * 1. **Handler Check**: Verifies handlers are registered for the event
+	 * 2. **Schema Validation**: Validates data against incomingSchema if present
+	 * 3. **Handler Execution**: Calls all registered handlers with validated data
+	 * 4. **Error Collection**: Logs individual handler errors and throws if any fail
+	 */
 	handleEvent(eventName: string, data: InferSchemaType<Schema>) {
 		const handlers = this.eventHandlers.get(eventName);
 
+		// Check if handlers are registered
 		if (!handlers?.length) {
 			logger.warn(
 				`No handlers registered for event "${eventName}". Did you forget to call .on("${eventName}", handler)?`,
@@ -71,6 +196,7 @@ export class EventEmitter {
 			return;
 		}
 
+		// Validate incoming data
 		let validatedData = data;
 		if (this.incomingSchema) {
 			try {
@@ -88,6 +214,7 @@ export class EventEmitter {
 			}
 		}
 
+		// Execute all handlers and collect errors
 		let hasErrors = false;
 		handlers.forEach((handler, index) => {
 			try {
@@ -106,6 +233,7 @@ export class EventEmitter {
 			}
 		});
 
+		// Throw if any handlers failed
 		if (hasErrors) {
 			throw new Error(
 				`One or more handlers failed for event "${eventName}". Check logs for details.`,
@@ -113,15 +241,34 @@ export class EventEmitter {
 		}
 	}
 
+	/**
+	 * Removes event handlers for a specific event
+	 * Can remove all handlers for an event or a specific handler function
+	 *
+	 * @param event - Event name to remove handlers from
+	 * @param callback - Optional specific handler to remove. If not provided, removes all handlers for the event
+	 *
+	 * @example
+	 * ```typescript
+	 * // Remove specific handler
+	 * emitter.off('message', myMessageHandler);
+	 *
+	 * // Remove all handlers for an event
+	 * emitter.off('message');
+	 * ```
+	 */
 	off(event: string, callback?: EventHandler) {
 		if (!callback) {
+			// Remove all handlers for the event
 			this.eventHandlers.delete(event as string);
 		} else {
+			// Remove specific handler
 			const handlers = this.eventHandlers.get(event as string);
 			if (handlers) {
 				const index = handlers.indexOf(callback as EventHandler);
 				if (index !== -1) {
 					handlers.splice(index, 1);
+					// Clean up empty handler arrays
 					if (handlers.length === 0) {
 						this.eventHandlers.delete(event as string);
 					}
@@ -130,6 +277,27 @@ export class EventEmitter {
 		}
 	}
 
+	/**
+	 * Registers an event handler for a specific event
+	 * Multiple handlers can be registered for the same event
+	 *
+	 * @param event - Event name to listen for
+	 * @param callback - Handler function to execute when the event is received
+	 *
+	 * @example
+	 * ```typescript
+	 * // Register a message handler
+	 * emitter.on('message', (data) => {
+	 *   console.log('Received message:', data.text);
+	 * });
+	 *
+	 * // Register multiple handlers for the same event
+	 * emitter.on('userJoined', logUserJoin);
+	 * emitter.on('userJoined', notifyOtherUsers);
+	 * ```
+	 *
+	 * Note: If no callback is provided, an error is logged and the handler is not registered
+	 */
 	on(event: string, callback?: EventHandler): void {
 		if (!callback) {
 			logger.error(
@@ -138,6 +306,7 @@ export class EventEmitter {
 			return;
 		}
 
+		// Get existing handlers or create new array
 		const handlers = this.eventHandlers.get(event as string) || [];
 		handlers.push(callback);
 		this.eventHandlers.set(event as string, handlers);

--- a/packages/rpc/src/sockets/io.ts
+++ b/packages/rpc/src/sockets/io.ts
@@ -1,22 +1,105 @@
 import { logger } from "./logger";
 
+/**
+ * IO class for managing WebSocket communications through Redis pub/sub
+ * Provides type-safe event broadcasting to connected clients with room-based targeting
+ *
+ * @template OutgoingEvents - Type definition for events that can be sent to clients
+ *
+ * Features:
+ * - **Type Safety**: Full TypeScript inference for event names and data
+ * - **Room Support**: Target specific rooms or broadcast to all clients
+ * - **Redis Integration**: Uses Upstash Redis for scalable pub/sub messaging
+ * - **Fluent Interface**: Chainable methods for intuitive API usage
+ * - **Automatic Cleanup**: Resets target room after each emission
+ *
+ * @example
+ * ```typescript
+ * interface GameEvents {
+ *   playerJoined: { playerId: string; name: string };
+ *   gameStarted: { gameId: string; players: string[] };
+ *   scoreUpdate: { playerId: string; score: number };
+ * }
+ *
+ * const io = new IO<GameEvents>(redisUrl, redisToken);
+ *
+ * // Broadcast to all clients
+ * await io.emit('gameStarted', { gameId: '123', players: ['Alice', 'Bob'] });
+ *
+ * // Send to specific room
+ * await io.to('room-123').emit('scoreUpdate', { playerId: 'Alice', score: 100 });
+ * ```
+ */
 export class IO<OutgoingEvents> {
+	/** Current target room for the next emission, null for broadcast to all */
 	private targetRoom: string | null = null;
+
+	/** Upstash Redis REST API URL for pub/sub operations */
 	private redisUrl: string;
+
+	/** Authentication token for Upstash Redis API */
 	private redisToken: string;
 
+	/**
+	 * Creates a new IO instance for WebSocket communication management
+	 *
+	 * @param redisUrl - Upstash Redis REST API URL (should include https://)
+	 * @param redisToken - Authentication token for Upstash Redis API
+	 *
+	 * @example
+	 * ```typescript
+	 * const io = new IO(
+	 *   process.env.UPSTASH_REDIS_REST_URL,
+	 *   process.env.UPSTASH_REDIS_REST_TOKEN
+	 * );
+	 * ```
+	 *
+	 * Note: The Redis URL and token are typically obtained from Upstash Redis dashboard
+	 * and should be stored as environment variables for security.
+	 */
 	constructor(redisUrl: string, redisToken: string) {
 		this.redisUrl = redisUrl;
 		this.redisToken = redisToken;
 	}
 
 	/**
-	 * Sends to all connected clients (broadcast)
+	 * Emits an event to connected clients through Redis pub/sub
+	 * Sends to a specific room if targeted, or broadcasts to all clients
+	 *
+	 * @template K - Event name type constrained to keys of OutgoingEvents
+	 * @param event - Type-safe event name from the OutgoingEvents interface
+	 * @param data - Event data matching the type defined for this event
+	 * @returns Promise that resolves when the message is published to Redis
+	 *
+	 * @example
+	 * ```typescript
+	 * // Type-safe event emission
+	 * await io.emit('playerJoined', {
+	 *   playerId: 'user123',
+	 *   name: 'Alice'
+	 * });
+	 *
+	 * // Emit to specific room
+	 * await io.to('game-room-1').emit('gameStarted', {
+	 *   gameId: 'game123',
+	 *   players: ['Alice', 'Bob']
+	 * });
+	 * ```
+	 *
+	 * Process:
+	 * 1. **Room Check**: If a target room is set, publishes to that room's Redis channel
+	 * 2. **Redis Publish**: Sends event and data as JSON array to Redis pub/sub
+	 * 3. **Logging**: Records the emission for debugging and monitoring
+	 * 4. **Cleanup**: Resets target room to null for next emission
+	 *
+	 * Note: The target room is automatically reset after each emission to prevent
+	 * accidental reuse. Use `.to(room)` before each `.emit()` call when targeting rooms.
 	 */
 	async emit<K extends keyof OutgoingEvents>(
 		event: K,
 		data: OutgoingEvents[K],
 	) {
+		// Publish to Redis if a target room is specified
 		if (this.targetRoom) {
 			await fetch(`${this.redisUrl}/publish/${this.targetRoom}`, {
 				method: "POST",
@@ -28,17 +111,43 @@ export class IO<OutgoingEvents> {
 			});
 		}
 
+		// Log the emission for debugging and monitoring
 		logger.info(`IO emitted to room "${this.targetRoom}":`, {
 			event,
 			data,
 		});
 
-		// Reset target room after emitting
+		// Reset target room after emitting to prevent accidental reuse
 		this.targetRoom = null;
 	}
 
 	/**
-	 * Sends to all in a room
+	 * Targets a specific room for the next emission
+	 * Returns the IO instance for method chaining with emit()
+	 *
+	 * @param room - Room identifier to target for the next emission
+	 * @returns The IO instance for method chaining
+	 *
+	 * @example
+	 * ```typescript
+	 * // Target a specific room and emit
+	 * await io.to('chat-room-general').emit('message', {
+	 *   user: 'Alice',
+	 *   text: 'Hello everyone!'
+	 * });
+	 *
+	 * // Target multiple rooms with separate calls
+	 * await io.to('room-1').emit('notification', { type: 'info' });
+	 * await io.to('room-2').emit('notification', { type: 'warning' });
+	 * ```
+	 *
+	 * Behavior:
+	 * - **Fluent Interface**: Enables chaining with `.emit()` for clean syntax
+	 * - **Single Use**: Target room is reset after each emission
+	 * - **Room Scoping**: Only clients subscribed to the specified room receive the message
+	 *
+	 * Note: If `.to()` is not called before `.emit()`, the message will broadcast
+	 * to all connected clients (global broadcast).
 	 */
 	to(room: string): this {
 		this.targetRoom = room;

--- a/packages/rpc/src/sockets/socket.ts
+++ b/packages/rpc/src/sockets/socket.ts
@@ -19,13 +19,13 @@ export interface SystemEvents {
 	onError: Error;
 }
 
-export type EventKeys<T> = T extends ZodObject
+type EventKeys<T> = T extends ZodObject
 	? keyof T["shape"]
 	: T extends Record<PropertyKey, unknown>
 		? keyof T
 		: string;
 
-export type EventData<T, K extends PropertyKey> = T extends ZodObject
+type EventData<T, K extends PropertyKey> = T extends ZodObject
 	? K extends keyof T["shape"]
 		? T["shape"][K] extends ZodType
 			? z.infer<T["shape"][K]>

--- a/packages/rpc/src/sockets/socket.ts
+++ b/packages/rpc/src/sockets/socket.ts
@@ -7,24 +7,45 @@ import {
 	type InferSchemaType,
 } from "./event-emitter";
 
+/**
+ * Configuration options for ServerSocket initialization
+ */
 interface ServerSocketOptions {
+	/** Upstash Redis REST API URL */
 	redisUrl: string;
+	/** Authentication token for Upstash Redis API */
 	redisToken: string;
+	/** Zod schema for validating incoming messages */
 	incomingSchema: ZodObject | void;
+	/** Zod schema for validating outgoing messages */
 	outgoingSchema: ZodObject | void;
 }
 
+/**
+ * System-level events that are automatically handled by the socket infrastructure
+ */
 export interface SystemEvents {
+	/** Fired when a client connects to the WebSocket */
 	onConnect: void;
+	/** Fired when an error occurs in the WebSocket connection */
 	onError: Error;
 }
 
+/**
+ * Extracts event key names from schema types
+ * @template T - Schema type to extract keys from
+ */
 type EventKeys<T> = T extends ZodObject
 	? keyof T["shape"]
 	: T extends Record<PropertyKey, unknown>
 		? keyof T
 		: string;
 
+/**
+ * Infers event data types from schema and event key
+ * @template T - Schema type containing event definitions
+ * @template K - Event key to extract data type for
+ */
 type EventData<T, K extends PropertyKey> = T extends ZodObject
 	? K extends keyof T["shape"]
 		? T["shape"][K] extends ZodType
@@ -37,52 +58,132 @@ type EventData<T, K extends PropertyKey> = T extends ZodObject
 			: never
 		: unknown;
 
+/**
+ * Server-side WebSocket connection handler with Redis pub/sub integration
+ * Manages individual client connections with room-based messaging, heartbeat monitoring,
+ * and automatic reconnection handling
+ *
+ * @template IncomingEvents - Type definition for events that can be received from clients
+ * @template OutgoingEvents - Type definition for events that can be sent to clients
+ *
+ * Features:
+ * - **Room Management**: Join/leave rooms for targeted messaging
+ * - **Redis Integration**: Scalable pub/sub messaging through Upstash Redis
+ * - **Heartbeat Monitoring**: Automatic connection health checks with reconnection
+ * - **Schema Validation**: Type-safe message validation using Zod schemas
+ * - **Event Handling**: Comprehensive event system with error handling
+ * - **Resource Cleanup**: Proper cleanup of timers and subscriptions
+ *
+ * @example
+ * ```typescript
+ * interface ChatEvents {
+ *   message: { user: string; text: string };
+ *   userJoined: { userId: string; name: string };
+ * }
+ *
+ * const socket = new ServerSocket<ChatEvents, ChatEvents>(websocket, {
+ *   redisUrl: process.env.UPSTASH_REDIS_REST_URL,
+ *   redisToken: process.env.UPSTASH_REDIS_REST_TOKEN,
+ *   incomingSchema: chatSchema,
+ *   outgoingSchema: chatSchema
+ * });
+ *
+ * // Join a chat room
+ * await socket.join('general-chat');
+ *
+ * // Listen for messages
+ * socket.on('message', (data) => {
+ *   console.log(`${data.user}: ${data.text}`);
+ * });
+ * ```
+ */
 export class ServerSocket<IncomingEvents, OutgoingEvents> {
+	/** Current room the socket is subscribed to */
 	private room = "DEFAULT_ROOM";
+
+	/** WebSocket connection instance */
 	private ws: WebSocket;
+
+	/** Map of AbortControllers for managing Redis subscriptions */
 	private controllers: Map<string, AbortController> = new Map();
+
+	/** EventEmitter instance for handling WebSocket events */
 	private emitter: EventEmitter;
 
-	// private redis: Redis
+	/** Upstash Redis REST API URL */
 	private redisUrl: string;
+
+	/** Authentication token for Upstash Redis API */
 	private redisToken: string;
+
+	/** Map tracking last ping timestamps for heartbeat monitoring */
 	private lastPingTimes: Map<string, number> = new Map();
+
+	/** Map of heartbeat timers for connection health monitoring */
 	private heartbeatTimers: Map<
 		string,
 		{
+			/** Timer for sending periodic ping messages */
 			sender: NodeJS.Timeout;
+			/** Timer for monitoring ping response timeouts */
 			monitor: NodeJS.Timeout;
 		}
 	> = new Map();
 
+	/**
+	 * Creates a new ServerSocket instance for managing a WebSocket connection
+	 *
+	 * @param ws - WebSocket connection to manage
+	 * @param opts - Configuration options including Redis credentials and schemas
+	 *
+	 * @example
+	 * ```typescript
+	 * const socket = new ServerSocket(websocket, {
+	 *   redisUrl: 'https://your-redis.upstash.io',
+	 *   redisToken: 'your-redis-token',
+	 *   incomingSchema: z.object({ type: z.string(), data: z.any() }),
+	 *   outgoingSchema: z.object({ event: z.string(), payload: z.any() })
+	 * });
+	 * ```
+	 */
 	constructor(ws: WebSocket, opts: ServerSocketOptions) {
 		const { incomingSchema, outgoingSchema, redisUrl, redisToken } = opts;
 
 		this.redisUrl = redisUrl;
 		this.redisToken = redisToken;
-		// this.redis = new Redis({
-		//   url: redisUrl,
-		//   token: redisToken,
-		// })
 
 		this.ws = ws;
 		this.emitter = new EventEmitter(ws, { incomingSchema, outgoingSchema });
 	}
 
+	/**
+	 * Gets the list of rooms this socket is currently subscribed to
+	 * @returns Array of room names (currently only supports one room)
+	 */
 	get rooms() {
 		return [this.room];
 	}
 
+	/**
+	 * Closes the WebSocket connection and cleans up all resources
+	 * Aborts all Redis subscriptions and clears heartbeat timers
+	 *
+	 * @example
+	 * ```typescript
+	 * // Clean shutdown
+	 * socket.close();
+	 * ```
+	 */
 	close() {
 		this.ws.close();
 
-		// clear all active subscriptions
+		// Clear all active Redis subscriptions
 		for (const controller of this.controllers.values()) {
 			controller.abort();
 		}
 		this.controllers.clear();
 
-		// clear all heartbeat timers
+		// Clear all heartbeat monitoring timers
 		for (const timers of this.heartbeatTimers.values()) {
 			clearInterval(timers.sender);
 			clearInterval(timers.monitor);
@@ -90,6 +191,22 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 		this.heartbeatTimers.clear();
 	}
 
+	/**
+	 * Removes an event listener for incoming events
+	 *
+	 * @template K - Event key type constrained to incoming events and system events
+	 * @param event - Event name to remove listener from
+	 * @param callback - Optional specific callback to remove. If not provided, removes all listeners
+	 *
+	 * @example
+	 * ```typescript
+	 * // Remove specific handler
+	 * socket.off('message', myMessageHandler);
+	 *
+	 * // Remove all handlers for an event
+	 * socket.off('message');
+	 * ```
+	 */
 	off<K extends keyof IncomingEvents & SystemEvents>(
 		event: K,
 		callback?: (data: IncomingEvents[K]) => unknown,
@@ -97,6 +214,26 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 		return this.emitter.off(event as string, callback as EventHandler);
 	}
 
+	/**
+	 * Registers an event listener for incoming events
+	 *
+	 * @template K - Event key type from the IncomingEvents schema
+	 * @param event - Event name to listen for
+	 * @param callback - Handler function to execute when the event is received
+	 *
+	 * @example
+	 * ```typescript
+	 * // Listen for chat messages
+	 * socket.on('message', (data) => {
+	 *   console.log(`Received: ${data.text} from ${data.user}`);
+	 * });
+	 *
+	 * // Listen for system events
+	 * socket.on('onConnect', () => {
+	 *   console.log('Client connected');
+	 * });
+	 * ```
+	 */
 	on<K extends EventKeys<IncomingEvents>>(
 		event: K,
 		callback?: (data: EventData<IncomingEvents, K>) => unknown,
@@ -104,6 +241,23 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 		return this.emitter.on(event as string, callback as EventHandler);
 	}
 
+	/**
+	 * Emits an event to the connected client
+	 *
+	 * @template K - Event key type from the OutgoingEvents schema
+	 * @param event - Event name to emit
+	 * @param data - Event data matching the schema for this event
+	 * @returns Promise<boolean> or boolean indicating if the message was sent successfully
+	 *
+	 * @example
+	 * ```typescript
+	 * // Send a message to the client
+	 * const success = await socket.emit('notification', {
+	 *   type: 'info',
+	 *   message: 'Welcome to the chat!'
+	 * });
+	 * ```
+	 */
 	emit<K extends EventKeys<OutgoingEvents>>(
 		event: K,
 		data: EventData<OutgoingEvents, K>,
@@ -111,10 +265,41 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 		return this.emitter.emit(event as string, data);
 	}
 
+	/**
+	 * Handles incoming events from the WebSocket connection
+	 * Delegates to the internal EventEmitter for validation and processing
+	 *
+	 * @param eventName - Name of the event to handle
+	 * @param eventData - Event data to validate and process
+	 *
+	 * @internal
+	 */
 	handleEvent(eventName: string, eventData: InferSchemaType<Schema>) {
 		this.emitter.handleEvent(eventName, eventData);
 	}
 
+	/**
+	 * Joins a Redis pub/sub room for receiving targeted messages
+	 * Establishes subscription and starts heartbeat monitoring
+	 *
+	 * @param room - Room identifier to join
+	 * @returns Promise that resolves when the room is successfully joined
+	 *
+	 * @example
+	 * ```typescript
+	 * // Join a game room
+	 * await socket.join('game-room-123');
+	 *
+	 * // Join a chat channel
+	 * await socket.join('chat-general');
+	 * ```
+	 *
+	 * Process:
+	 * 1. Sets the current room
+	 * 2. Establishes Redis subscription
+	 * 3. Starts heartbeat monitoring
+	 * 4. Handles subscription errors gracefully
+	 */
 	async join(room: string): Promise<void> {
 		this.room = room;
 		logger.info(`Socket trying to join room: "${room}".`);
@@ -126,6 +311,17 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 			.then(() => this.createHeartbeat(room));
 	}
 
+	/**
+	 * Leaves a Redis pub/sub room and stops receiving messages
+	 *
+	 * @param room - Room identifier to leave
+	 *
+	 * @example
+	 * ```typescript
+	 * // Leave current room
+	 * socket.leave('game-room-123');
+	 * ```
+	 */
 	leave(room: string) {
 		const controller = this.controllers.get(room);
 
@@ -140,8 +336,16 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 		}
 	}
 
+	/**
+	 * Creates heartbeat monitoring system for connection health
+	 * Sets up periodic ping messages and timeout detection
+	 *
+	 * @param room - Room to monitor heartbeat for
+	 * @private
+	 */
 	private createHeartbeat(room: string) {
 		const heartbeat = {
+			// Send ping every 30 seconds
 			sender: setInterval(async () => {
 				await fetch(`${this.redisUrl}/publish/${room}`, {
 					method: "POST",
@@ -153,9 +357,11 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 				});
 			}, 30000),
 
+			// Monitor for ping responses every 5 seconds
 			monitor: setInterval(() => {
 				const lastPingTime = this.lastPingTimes.get(room) ?? 0;
 
+				// If no ping response in 45 seconds, reconnect
 				if (Date.now() - lastPingTime > 45000) {
 					logger.warn("Heartbeat timeout detected");
 					this.unsubscribe(room).then(() => this.subscribe(room));
@@ -166,14 +372,23 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 		this.heartbeatTimers.set(room, heartbeat);
 	}
 
+	/**
+	 * Establishes Redis subscription for real-time message streaming
+	 * Creates an AbortController for subscription management
+	 *
+	 * @param room - Room to subscribe to
+	 * @returns Promise that resolves when subscription is established
+	 * @private
+	 */
 	private async subscribe(room: string): Promise<void> {
 		try {
 			const controller = new AbortController();
 			this.controllers.set(room, controller);
 
-			// initialize heartbeat
+			// Initialize heartbeat tracking
 			this.lastPingTimes.set(room, Date.now());
 
+			// Establish Server-Sent Events stream
 			const stream = await fetch(`${this.redisUrl}/subscribe/${room}`, {
 				headers: {
 					Authorization: `Bearer ${this.redisToken}`,
@@ -186,10 +401,9 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 			const decoder = new TextDecoder();
 			const buffer = "";
 
-			// Start processing messages in the background
+			// Start background message processing
 			this.processStreamMessages(reader, decoder, buffer, room);
 
-			// Return immediately after connection is established
 			return;
 		} catch (err) {
 			logger.error("Error establishing subscription:", err);
@@ -197,6 +411,16 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 		}
 	}
 
+	/**
+	 * Processes incoming Redis stream messages in real-time
+	 * Handles message parsing, heartbeat tracking, and WebSocket forwarding
+	 *
+	 * @param reader - ReadableStream reader for processing chunks
+	 * @param decoder - TextDecoder for converting bytes to strings
+	 * @param buffer - String buffer for incomplete messages
+	 * @param room - Room being processed
+	 * @private
+	 */
 	private async processStreamMessages(
 		reader: ReadableStreamDefaultReader<Uint8Array> | undefined,
 		decoder: TextDecoder,
@@ -213,6 +437,7 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 				const chunk = decoder.decode(value);
 				newBuffer += chunk;
 
+				// Split messages by newlines
 				const messages = newBuffer.split("\n");
 				newBuffer = messages.pop() || "";
 
@@ -221,8 +446,7 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 					if (message.startsWith("data: ")) {
 						const data = message.slice(6);
 						try {
-							// extract payload from message format: message,room,payload
-							// skip first two commas to get the start of the payload
+							// Parse Redis message format: message,room,payload
 							const firstCommaIndex = data.indexOf(",");
 							const secondCommaIndex = data.indexOf(",", firstCommaIndex + 1);
 
@@ -240,11 +464,13 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 
 							const parsed = JSON.parse(payloadStr);
 
+							// Handle heartbeat responses
 							if (parsed[0] === "ping") {
 								logger.info("Heartbeat received successfully");
 								this.lastPingTimes.set(room, Date.now());
 							}
 
+							// Forward message to WebSocket client
 							if (this.ws.readyState === WebSocket.OPEN) {
 								this.ws.send(JSON.stringify(parsed));
 							} else {
@@ -261,6 +487,12 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 		}
 	}
 
+	/**
+	 * Unsubscribes from a Redis room and cleans up the controller
+	 *
+	 * @param room - Room to unsubscribe from
+	 * @private
+	 */
 	private async unsubscribe(room: string) {
 		const controller = this.controllers.get(room);
 		if (controller) {
@@ -273,22 +505,98 @@ export class ServerSocket<IncomingEvents, OutgoingEvents> {
 	}
 }
 
+/**
+ * Schema type for client socket validation
+ */
 type Schema = ZodObject | undefined;
 
+/**
+ * Client-side WebSocket connection with automatic reconnection and event handling
+ * Manages WebSocket connections from the client side with built-in reconnection logic,
+ * heartbeat monitoring, and type-safe event communication
+ *
+ * @template IncomingEvents - Type definition for events that can be received from server
+ * @template OutgoingEvents - Type definition for events that can be sent to server
+ *
+ * Features:
+ * - **Automatic Reconnection**: Handles connection drops with retry logic
+ * - **Schema Validation**: Type-safe message validation using Zod schemas
+ * - **Event Handling**: Comprehensive event system with error handling
+ * - **Connection State**: Tracks connection status and manages cleanup
+ * - **Development Helpers**: Provides helpful error messages for common issues
+ *
+ * @example
+ * ```typescript
+ * interface GameEvents {
+ *   move: { player: string; position: { x: number; y: number } };
+ *   gameOver: { winner: string; score: number };
+ * }
+ *
+ * const socket = new ClientSocket<GameEvents, GameEvents>(
+ *   'wss://api.example.com/game',
+ *   {
+ *     incomingSchema: gameEventSchema,
+ *     outgoingSchema: gameEventSchema
+ *   }
+ * );
+ *
+ * // Listen for game events
+ * socket.on('gameOver', (data) => {
+ *   console.log(`Game over! Winner: ${data.winner}`);
+ * });
+ *
+ * // Send player moves
+ * socket.emit('move', { player: 'alice', position: { x: 10, y: 20 } });
+ * ```
+ */
 export class ClientSocket<IncomingEvents extends SystemEvents, OutgoingEvents> {
+	/** WebSocket connection instance */
 	private ws!: WebSocket;
+
+	/** EventEmitter instance for handling WebSocket events */
 	private emitter!: EventEmitter;
 
+	/** WebSocket URL for connection */
 	private url: string | URL;
+
+	/** Zod schema for validating incoming messages */
 	private incomingSchema: Schema;
+
+	/** Zod schema for validating outgoing messages */
 	private outgoingSchema: Schema;
 
+	/** Timer for sending periodic ping messages */
 	private pingTimer?: NodeJS.Timeout;
+
+	/** Timer for monitoring pong responses */
 	private pongTimer?: NodeJS.Timeout;
+
+	/** Counter for tracking reconnection attempts */
 	private reconnectAttempts = 0;
 
+	/** Current connection status */
 	isConnected = false;
 
+	/**
+	 * Creates a new ClientSocket instance and establishes connection
+	 *
+	 * @param url - WebSocket URL to connect to (ws:// or wss://)
+	 * @param options - Optional configuration including validation schemas
+	 * @param options.incomingSchema - Schema for validating incoming messages
+	 * @param options.outgoingSchema - Schema for validating outgoing messages
+	 *
+	 * @example
+	 * ```typescript
+	 * // Basic connection
+	 * const socket = new ClientSocket('wss://api.example.com/ws');
+	 *
+	 * // With schema validation
+	 * const socket = new ClientSocket('wss://api.example.com/ws', {
+	 *   incomingSchema: z.object({ type: z.string(), data: z.any() }),
+	 *   outgoingSchema: z.object({ event: z.string(), payload: z.any() })
+	 * });
+	 * ```
+	 */
 	constructor(
 		url: string | URL,
 		{
@@ -303,6 +611,12 @@ export class ClientSocket<IncomingEvents extends SystemEvents, OutgoingEvents> {
 		this.connect();
 	}
 
+	/**
+	 * Cleans up all timers and resources
+	 * Called during connection cleanup or before reconnection
+	 *
+	 * @private
+	 */
 	cleanup() {
 		if (this.pingTimer) {
 			clearInterval(this.pingTimer);
@@ -315,6 +629,15 @@ export class ClientSocket<IncomingEvents extends SystemEvents, OutgoingEvents> {
 		}
 	}
 
+	/**
+	 * Closes the WebSocket connection and cleans up resources
+	 *
+	 * @example
+	 * ```typescript
+	 * // Clean shutdown
+	 * socket.close();
+	 * ```
+	 */
 	close() {
 		this.cleanup();
 
@@ -325,9 +648,26 @@ export class ClientSocket<IncomingEvents extends SystemEvents, OutgoingEvents> {
 		this.isConnected = false;
 	}
 
+	/**
+	 * Establishes WebSocket connection with comprehensive event handling
+	 * Sets up automatic reconnection, error handling, and message processing
+	 *
+	 * @example
+	 * ```typescript
+	 * // Manually reconnect (usually automatic)
+	 * socket.connect();
+	 * ```
+	 *
+	 * Connection Process:
+	 * 1. Creates new WebSocket instance
+	 * 2. Preserves existing event handlers during reconnection
+	 * 3. Sets up error, open, close, and message event handlers
+	 * 4. Implements automatic reconnection with exponential backoff
+	 */
 	connect() {
 		const ws = new WebSocket(this.url);
 
+		// Preserve existing event handlers during reconnection
 		const existingHandlers = this.emitter?.eventHandlers;
 
 		this.emitter = new EventEmitter(ws, {
@@ -341,6 +681,7 @@ export class ClientSocket<IncomingEvents extends SystemEvents, OutgoingEvents> {
 
 		this.ws = ws;
 
+		// Handle connection errors with helpful development messages
 		ws.onerror = (err) => {
 			const url = (err.currentTarget as WebSocket)?.url;
 
@@ -364,6 +705,7 @@ Fix this issue: https://jsandy.app/docs/getting-started/local-development
 			this.emitter.handleEvent("onError", err);
 		};
 
+		// Handle successful connection
 		ws.onopen = () => {
 			console.info("Connected");
 			this.isConnected = true;
@@ -372,12 +714,14 @@ Fix this issue: https://jsandy.app/docs/getting-started/local-development
 			this.emitter.handleEvent("onConnect", undefined);
 		};
 
+		// Handle connection close with automatic reconnection
 		ws.onclose = () => {
 			console.warn("Connection closed, trying to reconnect...");
 			this.isConnected = false;
 
 			this.reconnectAttempts++;
 
+			// Retry up to 3 times with 1.5 second delay
 			if (this.reconnectAttempts < 3) {
 				setTimeout(() => this.connect(), 1500);
 			} else {
@@ -387,12 +731,12 @@ Fix this issue: https://jsandy.app/docs/getting-started/local-development
 			}
 		};
 
+		// Handle incoming messages with validation
 		ws.onmessage = (event) => {
 			const data = z.string().parse(event.data);
 			const eventSchema = z.tuple([z.string(), z.unknown()]);
 
 			const parsedData = JSON.parse(data);
-
 			const parseResult = eventSchema.safeParse(parsedData);
 
 			if (parseResult.success) {
@@ -407,6 +751,27 @@ Fix this issue: https://jsandy.app/docs/getting-started/local-development
 		};
 	}
 
+	/**
+	 * Emits an event to the server
+	 *
+	 * @template K - Event key type from the OutgoingEvents schema
+	 * @param event - Event name to emit
+	 * @param data - Event data matching the schema for this event
+	 * @returns Promise<boolean> or boolean indicating if the message was sent successfully
+	 *
+	 * @example
+	 * ```typescript
+	 * // Send a chat message
+	 * const success = await socket.emit('message', {
+	 *   text: 'Hello everyone!',
+	 *   timestamp: new Date()
+	 * });
+	 *
+	 * if (!success) {
+	 *   console.log('Failed to send message');
+	 * }
+	 * ```
+	 */
 	emit<K extends keyof OutgoingEvents>(
 		event: K,
 		data: OutgoingEvents[K],
@@ -414,17 +779,55 @@ Fix this issue: https://jsandy.app/docs/getting-started/local-development
 		return this.emitter.emit(event as string, data);
 	}
 
+	/**
+	 * Removes an event listener for incoming events
+	 *
+	 * @template K - Event key type constrained to incoming events and system events
+	 * @param event - Event name to remove listener from
+	 * @param callback - Optional specific callback to remove. If not provided, removes all listeners
+	 *
+	 * @example
+	 * ```typescript
+	 * // Remove specific handler
+	 * socket.off('message', myMessageHandler);
+	 *
+	 * // Remove all handlers for an event
+	 * socket.off('message');
+	 * ```
+	 */
 	off<K extends keyof IncomingEvents & SystemEvents>(
 		event: K,
-
 		callback?: (data: IncomingEvents[K]) => unknown,
 	) {
 		return this.emitter.off(event as string, callback as EventHandler);
 	}
 
+	/**
+	 * Registers an event listener for incoming events
+	 *
+	 * @template K - Event key type from the IncomingEvents schema
+	 * @param event - Event name to listen for
+	 * @param callback - Handler function to execute when the event is received
+	 *
+	 * @example
+	 * ```typescript
+	 * // Listen for server messages
+	 * socket.on('notification', (data) => {
+	 *   showNotification(data.message, data.type);
+	 * });
+	 *
+	 * // Listen for connection events
+	 * socket.on('onConnect', () => {
+	 *   console.log('Successfully connected to server');
+	 * });
+	 *
+	 * socket.on('onError', (error) => {
+	 *   console.error('Connection error:', error);
+	 * });
+	 * ```
+	 */
 	on<K extends keyof IncomingEvents>(
 		event: K,
-
 		callback?: (data: IncomingEvents[K]) => unknown,
 	) {
 		return this.emitter.on(event as string, callback as EventHandler);

--- a/packages/rpc/src/types.ts
+++ b/packages/rpc/src/types.ts
@@ -3,8 +3,7 @@ import type { Context, TypedResponse } from "hono";
 import type { Env, Input } from "hono/types";
 import type { StatusCode } from "hono/utils/http-status";
 import type { ZodObject, ZodRawShape, z } from "zod/v4";
-import type { Router } from "../router";
-import type { IO, ServerSocket } from "../sockets";
+import type { IO, ServerSocket } from "./sockets";
 
 /**
  * Represents the type returned by superjson.parse for a given type T
@@ -300,11 +299,3 @@ export type RouterRecord = Record<
 	string,
 	OperationType<ZodObject | void, ZodObject | void> | Record<string, unknown>
 >;
-
-/**
- * Infers the environment type from a Router instance
- * @template T - The Router type to infer environment from
- */
-export type InferRouterEnv<T> = T extends Router<RouterRecord, infer E>
-	? E
-	: never;

--- a/packages/rpc/src/types/index.ts
+++ b/packages/rpc/src/types/index.ts
@@ -1,12 +1,10 @@
-// types.ts - Fixed with better type inference
-
 import type superjson from "superjson";
 import type { Context, TypedResponse } from "hono";
 import type { Env, Input } from "hono/types";
 import type { StatusCode } from "hono/utils/http-status";
 import type { ZodObject, ZodRawShape, z } from "zod/v4";
-import type { Router } from "./router";
-import type { IO, ServerSocket } from "./sockets";
+import type { Router } from "../router";
+import type { IO, ServerSocket } from "../sockets";
 
 type SuperJSONParsedType<T> = ReturnType<typeof superjson.parse<T>>;
 

--- a/packages/rpc/src/types/index.ts
+++ b/packages/rpc/src/types/index.ts
@@ -6,27 +6,60 @@ import type { ZodObject, ZodRawShape, z } from "zod/v4";
 import type { Router } from "../router";
 import type { IO, ServerSocket } from "../sockets";
 
+/**
+ * Represents the type returned by superjson.parse for a given type T
+ * @template T - The type to be parsed by superjson
+ */
 type SuperJSONParsedType<T> = ReturnType<typeof superjson.parse<T>>;
 
+/**
+ * A typed response that uses SuperJSON for serialization
+ * @template T - The data type to be serialized
+ * @template U - The HTTP status code type, defaults to StatusCode
+ */
 export type SuperJSONTypedResponse<
 	T,
 	U extends StatusCode = StatusCode,
 > = TypedResponse<SuperJSONParsedType<T>, U, "json">;
 
+/**
+ * Configuration interface for router setup
+ */
 export interface RouterConfig {
+	/** Optional name identifier for the router */
 	name?: string;
 }
 
+/**
+ * Handler object that provides superjson serialization functionality
+ */
 export type SuperJSONHandler = {
+	/**
+	 * Serializes data using superjson and returns a typed response
+	 * @template T - The type of data to serialize
+	 * @param data - The data to serialize
+	 * @param status - Optional HTTP status code
+	 * @returns SuperJSON typed response
+	 */
 	superjson: <T>(data: T, status?: number) => SuperJSONTypedResponse<T>;
 };
 
+/**
+ * Extended Hono context that includes SuperJSON serialization capabilities
+ * @template E - Environment type, defaults to Env
+ * @template P - Path parameter type, defaults to string
+ * @template I - Input type, defaults to Input
+ */
 export type ContextWithSuperJSON<
 	E extends Env = Env,
 	P extends string = string,
 	I extends Input = Input,
 > = Context<E, P, I> & SuperJSONHandler;
 
+/**
+ * Infers the output type from a middleware function
+ * @template T - The middleware function type to infer from
+ */
 export type InferMiddlewareOutput<T> = T extends MiddlewareFunction<
 	unknown,
 	infer R,
@@ -35,34 +68,66 @@ export type InferMiddlewareOutput<T> = T extends MiddlewareFunction<
 	? R
 	: unknown;
 
+/**
+ * Function type for middleware operations with context chaining
+ * @template T - Context object type, defaults to Record<string, unknown>
+ * @template R - Return type, defaults to void
+ * @template E - Environment type, defaults to Env
+ */
 export type MiddlewareFunction<
 	T = Record<string, unknown>,
 	R = void,
 	E extends Env = Env,
 > = (params: {
+	/** Current context object */
 	ctx: T;
+	/** Function to call next middleware with optional context extension */
 	next: <B extends Record<string, unknown>>(args?: B) => Promise<B & T>;
+	/** Hono context with SuperJSON capabilities */
 	c: ContextWithSuperJSON<E>;
 }) => Promise<R>;
 
+/**
+ * Function type for emitting events to all connected clients
+ * @param event - Event name to emit
+ * @param data - Optional data to send with the event
+ * @returns Promise that resolves when event is emitted
+ */
 export type EmitFunction = (event: string, data?: unknown) => Promise<void>;
 
+/**
+ * Function type for emitting events to a specific room
+ * @param room - Room identifier to emit to
+ * @param data - Optional data to send with the event
+ * @returns Promise that resolves when event is emitted
+ */
 export type RoomEmitFunction = (room: string, data?: unknown) => Promise<void>;
 
-// Simplified WebSocket data inference
+/**
+ * Infers the data type from a WebSocket schema, returning void if not a ZodObject
+ * @template T - The schema type to infer from
+ */
 export type InferWebSocketData<T> = T extends ZodObject ? z.infer<T> : void;
 
+/**
+ * Handler object for WebSocket lifecycle events
+ * @template IncomingSchema - Schema type for incoming messages
+ * @template OutgoingSchema - Schema type for outgoing messages
+ */
 export type WebSocketHandler<IncomingSchema, OutgoingSchema> = {
+	/** Optional handler called when a client connects */
 	onConnect?: ({
 		socket,
 	}: {
 		socket: ServerSocket<IncomingSchema, OutgoingSchema>;
 	}) => unknown;
+	/** Optional handler called when a client disconnects */
 	onDisconnect?: ({
 		socket,
 	}: {
 		socket: ServerSocket<IncomingSchema, OutgoingSchema>;
 	}) => unknown;
+	/** Optional handler called when an error occurs */
 	onError?: ({
 		socket,
 		error,
@@ -72,29 +137,52 @@ export type WebSocketHandler<IncomingSchema, OutgoingSchema> = {
 	}) => unknown;
 };
 
+/**
+ * Operation definition for WebSocket endpoints
+ * @template IncomingSchema - Schema type for incoming messages
+ * @template OutgoingSchema - Schema type for outgoing messages
+ * @template E - Environment type, defaults to Env
+ */
 export type WebSocketOperation<
 	IncomingSchema,
 	OutgoingSchema,
 	E extends Env = Env,
 > = {
+	/** Operation type identifier */
 	type: "ws";
+	/** Optional schema for incoming messages */
 	incoming?: IncomingSchema;
+	/** Optional schema for outgoing messages */
 	outgoing?: OutgoingSchema;
+	/** Output format specification */
 	outputFormat: "ws";
+	/** Handler function that returns WebSocket event handlers */
 	handler: (params: {
+		/** IO interface for WebSocket communication */
 		io: IO<OutgoingSchema>;
+		/** Hono context with SuperJSON capabilities */
 		c: ContextWithSuperJSON<E>;
+		/** Current context object */
 		ctx: Record<string, unknown>;
 	}) => OptionalPromise<WebSocketHandler<IncomingSchema, OutgoingSchema>>;
+	/** Array of middleware functions to apply */
 	middlewares: MiddlewareFunction<Record<string, unknown>, unknown, E>[];
 };
 
+/**
+ * Union type for possible response types from route handlers
+ * @template Output - The output data type
+ */
 export type ResponseType<Output> =
 	| SuperJSONTypedResponse<Output>
 	| TypedResponse<Output, StatusCode, "text">
 	| Response
 	| void;
 
+/**
+ * Utility type to unwrap response types from promises and typed responses
+ * @template T - The response type to unwrap
+ */
 type UnwrapResponse<T> = Awaited<T> extends TypedResponse<infer U>
 	? U
 	: Awaited<T> extends SuperJSONTypedResponse<infer U>
@@ -105,43 +193,77 @@ type UnwrapResponse<T> = Awaited<T> extends TypedResponse<infer U>
 				? void
 				: T;
 
+/**
+ * Operation definition for GET HTTP endpoints
+ * @template Schema - Input schema type
+ * @template Return - Return type, defaults to OptionalPromise<ResponseType<unknown>>
+ * @template E - Environment type, defaults to Env
+ */
 export type GetOperation<
 	Schema,
 	Return = OptionalPromise<ResponseType<unknown>>,
 	E extends Env = Env,
 > = {
+	/** Operation type identifier */
 	type: "get";
+	/** Optional input validation schema */
 	schema?: Schema;
+	/** Handler function for the GET operation */
 	handler: (params: {
+		/** Hono context with SuperJSON capabilities */
 		c: ContextWithSuperJSON<E>;
+		/** Current context object */
 		ctx: Record<string, unknown>;
+		/** Validated input data based on schema */
 		input: InferSchema<Schema>;
 	}) => UnwrapResponse<OptionalPromise<Return>>;
+	/** Array of middleware functions to apply */
 	middlewares: MiddlewareFunction<Record<string, unknown>, unknown, E>[];
 };
 
+/**
+ * Operation definition for POST HTTP endpoints
+ * @template Schema - Input schema type
+ * @template Return - Return type, defaults to OptionalPromise<ResponseType<unknown>>
+ * @template E - Environment type, defaults to Env
+ */
 export type PostOperation<
 	Schema,
 	Return = OptionalPromise<ResponseType<unknown>>,
 	E extends Env = Env,
 > = {
+	/** Operation type identifier */
 	type: "post";
+	/** Optional input validation schema */
 	schema?: Schema;
+	/** Handler function for the POST operation */
 	handler: (params: {
+		/** Current context object */
 		ctx: Record<string, unknown>;
+		/** Hono context with SuperJSON capabilities */
 		c: ContextWithSuperJSON<E>;
+		/** Validated input data based on schema */
 		input: InferSchema<Schema>;
 	}) => UnwrapResponse<OptionalPromise<Return>>;
+	/** Array of middleware functions to apply */
 	middlewares: MiddlewareFunction<Record<string, unknown>, unknown, E>[];
 };
 
-// Fixed: Allow void schemas with simplified constraints
+/**
+ * Union type for all possible operation types
+ * @template I - Input schema type
+ * @template O - Output schema type
+ * @template E - Environment type, defaults to Env
+ */
 export type OperationType<I, O, E extends Env = Env> =
 	| GetOperation<I, O, E>
 	| PostOperation<I, O, E>
 	| WebSocketOperation<I, O, E>;
 
-// Simplified schema inference to avoid deep instantiation
+/**
+ * Infers TypeScript types from Zod schemas, returning void for non-ZodObject types
+ * @template T - The schema type to infer from
+ */
 export type InferSchema<T> = T extends ZodObject<
 	infer Shape extends ZodRawShape
 >
@@ -150,6 +272,10 @@ export type InferSchema<T> = T extends ZodObject<
 		}
 	: void;
 
+/**
+ * Infers the input type from various operation types
+ * @template T - The operation type to infer input from
+ */
 // biome-ignore lint/suspicious/noExplicitAny: We don't know what type the Env is
 export type InferInput<T> = T extends OperationType<infer I, unknown, any>
 	? InferSchema<I>
@@ -161,11 +287,24 @@ export type InferInput<T> = T extends OperationType<infer I, unknown, any>
 				? InferSchema<I>
 				: void;
 
+/**
+ * Utility type that allows a value to be either synchronous or wrapped in a Promise
+ * @template T - The value type
+ */
 export type OptionalPromise<T> = T | Promise<T>;
+
+/**
+ * Record type representing a collection of router operations and nested routes
+ */
 export type RouterRecord = Record<
 	string,
 	OperationType<ZodObject | void, ZodObject | void> | Record<string, unknown>
 >;
+
+/**
+ * Infers the environment type from a Router instance
+ * @template T - The Router type to infer environment from
+ */
 export type InferRouterEnv<T> = T extends Router<RouterRecord, infer E>
 	? E
 	: never;


### PR DESCRIPTION
# Add inline docs to help developers navigate and use code

## Description

Added comprehensive JSDoc documentation throughout the codebase to improve developer experience with detailed inline comments for all types, classes, and methods. The documentation includes parameter descriptions, usage examples, template parameter explanations, and feature highlights for the JSandy framework's type-safe API development tools, enhancing IDE intellisense and code navigation.

## Type of Change

- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `docs`: Documentation changes
- [ ] `style`: Code style changes (formatting, etc.)
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Maintenance tasks
- [ ] `breaking`: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Affected Packages

- [x] `@jsandy/rpc`
- [ ] `@jsandy/builder`
- [ ] `@jsandy/typescript-config`
- [ ] `@jsandy/biome-config`
- [ ] Root workspace/tooling