### PR TITLE
Add VS Code setup support in CLI project scaffolding

### DIFF
--- a/.changeset/soft-meals-marry.md
+++ b/.changeset/soft-meals-marry.md
@@ -1,0 +1,5 @@
+---
+"create-jsandy-app": minor
+---
+
+Add support for vscode directory setup

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -15,14 +15,9 @@
 		"christian-kohler.npm-intellisense",
 		"ms-vscode.hexeditor",
 		"redhat.vscode-yaml",
-		"ms-vscode.vscode-json",
 		"biomejs.biome",
 		"mtxr.sqltools",
-		"mtxr.sqltools-driver-pg",
-		"ms-vscode.vscode-json",
-		"redhat.vscode-yaml",
-		"ms-vscode.hexeditor",
-		"wix.vscode-import-cost"
+		"mtxr.sqltools-driver-pg"
 	],
 	"unwantedRecommendations": ["hookyqr.beautify", "ms-vscode.vscode-typescript"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,28 @@
+{
+	"recommendations": [
+		"ms-vscode.vscode-typescript-next",
+		"bradlc.vscode-tailwindcss",
+		"ms-vscode.vscode-json",
+		"christian-kohler.path-intellisense",
+		"formulahendry.auto-rename-tag",
+		"ms-vscode.vscode-react-native",
+		"eamodio.gitlens",
+		"github.vscode-github-actions",
+		"streetsidesoftware.code-spell-checker",
+		"usernamehw.errorlens",
+		"oderwat.indent-rainbow",
+		"wix.vscode-import-cost",
+		"christian-kohler.npm-intellisense",
+		"ms-vscode.hexeditor",
+		"redhat.vscode-yaml",
+		"ms-vscode.vscode-json",
+		"biomejs.biome",
+		"mtxr.sqltools",
+		"mtxr.sqltools-driver-pg",
+		"ms-vscode.vscode-json",
+		"redhat.vscode-yaml",
+		"ms-vscode.hexeditor",
+		"wix.vscode-import-cost"
+	],
+	"unwantedRecommendations": ["hookyqr.beautify", "ms-vscode.vscode-typescript"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,38 @@
 {
+	"typescript.preferences.quoteStyle": "double",
+	"typescript.preferences.includePackageJsonAutoImports": "on",
+	"typescript.preferences.preferTypeOnlyAutoImports": true,
+	"typescript.suggest.autoImports": true,
+	"typescript.updateImportsOnFileMove.enabled": "always",
+	"editor.formatOnSave": true,
+	"[markdown]": {
+		"editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
+	},
+	"files.eol": "\n",
+	"files.trimTrailingWhitespace": true,
+	"files.insertFinalNewline": true,
+	"emmet.includeLanguages": {
+		"typescript": "html",
+		"typescriptreact": "html"
+	},
+	"tailwindCSS.experimental.classRegex": [
+		["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
+		["cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
+		["cn\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
+		["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+	],
+	"tailwindCSS.includeLanguages": {
+		"typescript": "html",
+		"typescriptreact": "html"
+	},
+	"css.validate": false,
+	"scss.validate": false,
+	"less.validate": false,
 	"editor.defaultFormatter": "biomejs.biome",
 	"editor.codeActionsOnSave": {
-		"quickfix.biome": "explicit"
+		"quickfix.biome": "explicit",
+		"source.organizeImports.biome": "explicit"
 	},
-	"typescript.preferences.preferTypeOnlyAutoImports": true,
 	"[json]": {
 		"editor.defaultFormatter": "biomejs.biome"
 	},
@@ -16,28 +45,16 @@
 	"[jsonc]": {
 		"editor.defaultFormatter": "biomejs.biome"
 	},
-	"[javascript]": {
-		"editor.defaultFormatter": "biomejs.biome"
-	},
-	"[markdown]": {
-		"editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
-	},
-	"[properties]": {
-		"editor.defaultFormatter": "foxundermoon.shell-format"
-	},
-	"[ignore]": {
-		"editor.defaultFormatter": "foxundermoon.shell-format"
-	},
-	"[dotenv]": {
-		"editor.defaultFormatter": "foxundermoon.shell-format"
-	},
-	"[github-actions-workflow]": {
-		"editor.defaultFormatter": "esbenp.prettier-vscode"
-	},
 	"[css]": {
 		"editor.defaultFormatter": "biomejs.biome"
 	},
-	"[shellscript]": {
-		"editor.defaultFormatter": "foxundermoon.shell-format"
-	}
+	"[javascript]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"files.associations": {
+		"*.sql": "sql",
+		"drizzle.config.*": "typescript"
+	},
+	"sqltools.useNodeRuntime": true,
+	"sqltools.connections": []
 }

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -14,6 +14,7 @@ interface CliResults {
 		| "planetscale"
 		| undefined;
 	linter: Linter | undefined;
+	setupVSCode?: boolean; // New option
 	noInstall?: boolean;
 }
 
@@ -93,6 +94,25 @@ export async function runCli(): Promise<CliResults | undefined> {
 		return undefined;
 	}
 
+	const setupVSCode = await select({
+		message: "Would you like to set up recommended VS Code workspace settings?",
+		options: [
+			{
+				value: true,
+				label: "Yes - Configure VS Code settings and extensions",
+			},
+			{
+				value: false,
+				label: "No - Skip VS Code configuration",
+			},
+		],
+	});
+
+	if (isCancel(setupVSCode)) {
+		outro("Setup cancelled.");
+		return undefined;
+	}
+
 	let noInstall = noInstallFlag;
 	if (!noInstall) {
 		const pkgManager = getUserPkgManager();
@@ -116,6 +136,7 @@ export async function runCli(): Promise<CliResults | undefined> {
 		dialect,
 		provider,
 		linter,
+		setupVSCode,
 		noInstall,
 	};
 }

--- a/packages/cli/src/helpers/install-packages.ts
+++ b/packages/cli/src/helpers/install-packages.ts
@@ -62,5 +62,22 @@ export const installPackages = (options: InstallPackagesOptions) => {
 		}
 	}
 
+	console.log("Installers", JSON.stringify(installers, null, 2));
+	for (const [name, pkgOpts] of Object.entries(installers.ide)) {
+		if (pkgOpts.inUse) {
+			const spinner = ora(`Setting up IDE: ${name}...`).start();
+			try {
+				pkgOpts.installer(options);
+				spinner.succeed(
+					`Successfully configured IDE: ${chalk.green.bold(name)}`,
+				);
+			} catch (error) {
+				spinner.fail(`Failed to setup IDE: ${name}`);
+				logger.error(`Error configuring ${name}:`, error);
+				throw error;
+			}
+		}
+	}
+
 	logger.info("");
 };

--- a/packages/cli/src/helpers/install-packages.ts
+++ b/packages/cli/src/helpers/install-packages.ts
@@ -62,7 +62,6 @@ export const installPackages = (options: InstallPackagesOptions) => {
 		}
 	}
 
-	console.log("Installers", JSON.stringify(installers, null, 2));
 	for (const [name, pkgOpts] of Object.entries(installers.ide)) {
 		if (pkgOpts.inUse) {
 			const spinner = ora(`Setting up IDE: ${name}...`).start();

--- a/packages/cli/src/helpers/scaffold-project.ts
+++ b/packages/cli/src/helpers/scaffold-project.ts
@@ -1,9 +1,9 @@
+import path from "node:path";
+import type { Linter } from "@/cli";
 import type { InstallerMap, Provider } from "@/installers/index";
 import { getUserPkgManager } from "@/utils/get-user-pkg-manager";
-import path from "node:path";
 import { installBaseTemplate } from "./install-base-template";
 import { installPackages } from "./install-packages";
-import type { Linter } from "@/cli";
 
 interface ScaffoldProjectOptions {
 	projectName: string;
@@ -33,8 +33,6 @@ export const scaffoldProject = async ({
 		linter,
 		setupVSCode,
 	});
-
-	console.log("Setup VSCode", setupVSCode);
 
 	installPackages({
 		projectDir,

--- a/packages/cli/src/helpers/scaffold-project.ts
+++ b/packages/cli/src/helpers/scaffold-project.ts
@@ -10,6 +10,7 @@ interface ScaffoldProjectOptions {
 	installers: InstallerMap;
 	databaseProvider: Provider;
 	linter: Linter;
+	setupVSCode?: boolean;
 }
 
 export const scaffoldProject = async ({
@@ -17,6 +18,7 @@ export const scaffoldProject = async ({
 	projectName,
 	installers,
 	linter,
+	setupVSCode,
 }: ScaffoldProjectOptions) => {
 	const projectDir = path.resolve(process.cwd(), projectName);
 	const pkgManager = getUserPkgManager();
@@ -29,7 +31,10 @@ export const scaffoldProject = async ({
 		projectName,
 		databaseProvider,
 		linter,
+		setupVSCode,
 	});
+
+	console.log("Setup VSCode", setupVSCode);
 
 	installPackages({
 		projectDir,
@@ -39,6 +44,7 @@ export const scaffoldProject = async ({
 		projectName,
 		databaseProvider,
 		linter,
+		setupVSCode,
 	});
 
 	return projectDir;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,15 +16,16 @@ const main = async () => {
 		return;
 	}
 
-	const { projectName, orm, provider, linter } = results;
+	const { projectName, orm, provider, linter, setupVSCode } = results;
 
-	const installers = buildInstallerMap(orm, provider, linter);
+	const installers = buildInstallerMap(orm, provider, linter, setupVSCode);
 
 	const projectDir = await scaffoldProject({
 		databaseProvider: provider ?? "neon",
 		installers,
 		projectName,
 		linter: linter ?? "none",
+		setupVSCode,
 	});
 
 	try {

--- a/packages/cli/src/installers/index.ts
+++ b/packages/cli/src/installers/index.ts
@@ -5,6 +5,7 @@ import { noOrmInstaller } from "./no-orm";
 import { postgresInstaller } from "./postgres";
 import { vercelPostgresInstaller } from "./vercel-postgres";
 import { planetscaleInstaller } from "./planetscale";
+import { vscodeInstaller } from "./vscode"; // New import
 import type { Linter } from "@/cli";
 import { eslintInstaller } from "./eslint";
 import { biomeInstaller } from "./biome";
@@ -42,6 +43,12 @@ export type InstallerMap = {
 			installer: Installer;
 		};
 	};
+	ide: {
+		vscode: {
+			inUse: boolean;
+			installer: Installer;
+		};
+	};
 };
 
 export interface InstallerOptions {
@@ -53,6 +60,7 @@ export interface InstallerOptions {
 	projectName: string;
 	databaseProvider: Provider;
 	linter: Linter;
+	setupVSCode?: boolean;
 }
 
 export type Installer = (opts: InstallerOptions) => void;
@@ -61,6 +69,7 @@ export const buildInstallerMap = (
 	selectedOrm: Orm = "none",
 	selectedProvider?: Provider,
 	selectedLinter?: Linter,
+	setupVSCode?: boolean,
 ): InstallerMap => ({
 	orm: {
 		none: {
@@ -102,6 +111,12 @@ export const buildInstallerMap = (
 		biome: {
 			inUse: selectedLinter === "biome",
 			installer: biomeInstaller,
+		},
+	},
+	ide: {
+		vscode: {
+			inUse: setupVSCode === true,
+			installer: vscodeInstaller,
 		},
 	},
 });

--- a/packages/cli/src/installers/vscode.ts
+++ b/packages/cli/src/installers/vscode.ts
@@ -139,7 +139,6 @@ function createVSCodeExtensions(linter: string, orm: string) {
 
 		// Next.js/React specific
 		"ms-vscode.vscode-json",
-		"christian-kohler.path-intellisense",
 		"formulahendry.auto-rename-tag",
 		"ms-vscode.vscode-react-native",
 
@@ -150,7 +149,6 @@ function createVSCodeExtensions(linter: string, orm: string) {
 		// Productivity & Code Quality
 		"streetsidesoftware.code-spell-checker",
 		"usernamehw.errorlens",
-		"oderwat.indent-rainbow",
 		"wix.vscode-import-cost",
 		"christian-kohler.npm-intellisense",
 

--- a/packages/cli/src/installers/vscode.ts
+++ b/packages/cli/src/installers/vscode.ts
@@ -7,7 +7,7 @@ export const vscodeInstaller: Installer = ({
 	linter,
 	databaseProvider,
 }) => {
-	const orm = databaseProvider !== undefined ? "drizzle" : "none";
+	const orm = databaseProvider !== undefined ? databaseProvider : "none";
 	const vscodeDir = path.join(projectDir, ".vscode");
 	fs.ensureDirSync(vscodeDir);
 
@@ -173,14 +173,6 @@ function createVSCodeExtensions(linter: string, orm: string) {
 			"mtxr.sqltools-driver-pg", // PostgreSQL driver
 		);
 	}
-
-	// Additional helpful extensions
-	baseExtensions.push(
-		"ms-vscode.vscode-json",
-		"redhat.vscode-yaml",
-		"ms-vscode.hexeditor",
-		"wix.vscode-import-cost",
-	);
 
 	return {
 		recommendations: baseExtensions,

--- a/packages/cli/src/installers/vscode.ts
+++ b/packages/cli/src/installers/vscode.ts
@@ -7,18 +7,18 @@ export const vscodeInstaller: Installer = ({
 	linter,
 	databaseProvider,
 }) => {
-	const orm = databaseProvider !== undefined ? databaseProvider : "none";
+	const dbProvider = databaseProvider !== undefined ? databaseProvider : "none";
 	const vscodeDir = path.join(projectDir, ".vscode");
 	fs.ensureDirSync(vscodeDir);
 
 	// Create settings.json
-	const settings = createVSCodeSettings(linter, orm);
+	const settings = createVSCodeSettings(linter, dbProvider);
 	fs.writeJSONSync(path.join(vscodeDir, "settings.json"), settings, {
 		spaces: 2,
 	});
 
 	// Create extensions.json
-	const extensions = createVSCodeExtensions(linter, orm);
+	const extensions = createVSCodeExtensions(linter, dbProvider);
 	fs.writeJSONSync(path.join(vscodeDir, "extensions.json"), extensions, {
 		spaces: 2,
 	});

--- a/packages/cli/src/installers/vscode.ts
+++ b/packages/cli/src/installers/vscode.ts
@@ -1,0 +1,195 @@
+import path from "node:path";
+import fs from "fs-extra";
+import type { Installer } from "./index";
+
+export const vscodeInstaller: Installer = ({
+	projectDir,
+	linter,
+	databaseProvider,
+}) => {
+	const orm = databaseProvider !== undefined ? "drizzle" : "none";
+	const vscodeDir = path.join(projectDir, ".vscode");
+	fs.ensureDirSync(vscodeDir);
+
+	// Create settings.json
+	const settings = createVSCodeSettings(linter, orm);
+	fs.writeJSONSync(path.join(vscodeDir, "settings.json"), settings, {
+		spaces: 2,
+	});
+
+	// Create extensions.json
+	const extensions = createVSCodeExtensions(linter, orm);
+	fs.writeJSONSync(path.join(vscodeDir, "extensions.json"), extensions, {
+		spaces: 2,
+	});
+};
+
+function createVSCodeSettings(linter: string, orm: string) {
+	const baseSettings = {
+		// TypeScript settings
+		"typescript.preferences.quoteStyle": "double",
+		"typescript.preferences.includePackageJsonAutoImports": "on",
+		"typescript.preferences.preferTypeOnlyAutoImports": true,
+		"typescript.suggest.autoImports": true,
+		"typescript.updateImportsOnFileMove.enabled": "always",
+
+		// Editor settings
+		"editor.formatOnSave": true,
+		"[markdown]": {
+			"editor.defaultFormatter": "DavidAnson.vscode-markdownlint",
+		},
+
+		// File settings
+		"files.eol": "\n",
+		"files.trimTrailingWhitespace": true,
+		"files.insertFinalNewline": true,
+
+		// Next.js specific
+		"emmet.includeLanguages": {
+			typescript: "html",
+			typescriptreact: "html",
+		},
+
+		// Tailwind CSS
+		"tailwindCSS.experimental.classRegex": [
+			["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
+			["cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
+			["cn\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
+			["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
+		],
+		"tailwindCSS.includeLanguages": {
+			typescript: "html",
+			typescriptreact: "html",
+		},
+		"css.validate": false,
+		"scss.validate": false,
+		"less.validate": false,
+	};
+
+	// Linter-specific settings
+	if (linter === "eslint") {
+		Object.assign(baseSettings, {
+			"editor.defaultFormatter": "esbenp.prettier-vscode",
+			"eslint.validate": [
+				"javascript",
+				"javascriptreact",
+				"typescript",
+				"typescriptreact",
+			],
+			"editor.codeActionsOnSave": {
+				"source.fixAll.eslint": "explicit",
+				"source.organizeImports": "explicit",
+			},
+		});
+	} else if (linter === "biome") {
+		Object.assign(baseSettings, {
+			"editor.defaultFormatter": "biomejs.biome",
+			"editor.codeActionsOnSave": {
+				"quickfix.biome": "explicit",
+				"source.organizeImports.biome": "explicit",
+			},
+			"[json]": {
+				"editor.defaultFormatter": "biomejs.biome",
+			},
+			"[typescriptreact]": {
+				"editor.defaultFormatter": "biomejs.biome",
+			},
+			"[typescript]": {
+				"editor.defaultFormatter": "biomejs.biome",
+			},
+			"[jsonc]": {
+				"editor.defaultFormatter": "biomejs.biome",
+			},
+			"[css]": {
+				"editor.defaultFormatter": "biomejs.biome",
+			},
+			"[javascript]": {
+				"editor.defaultFormatter": "biomejs.biome",
+			},
+		});
+	} else {
+		// No linter - just use Prettier
+		Object.assign(baseSettings, {
+			"editor.defaultFormatter": "esbenp.prettier-vscode",
+		});
+	}
+
+	// Database-specific settings
+	if (orm === "drizzle") {
+		Object.assign(baseSettings, {
+			// Drizzle Kit integration
+			"files.associations": {
+				"*.sql": "sql",
+				"drizzle.config.*": "typescript",
+			},
+			// SQL formatting (if using SQL tools extension)
+			"sqltools.useNodeRuntime": true,
+			"sqltools.connections": [],
+		});
+	}
+
+	return baseSettings;
+}
+
+function createVSCodeExtensions(linter: string, orm: string) {
+	const baseExtensions = [
+		// Essential TypeScript/React
+		"ms-vscode.vscode-typescript-next",
+		"bradlc.vscode-tailwindcss",
+
+		// Next.js/React specific
+		"ms-vscode.vscode-json",
+		"christian-kohler.path-intellisense",
+		"formulahendry.auto-rename-tag",
+		"ms-vscode.vscode-react-native",
+
+		// Git integration
+		"eamodio.gitlens",
+		"github.vscode-github-actions",
+
+		// Productivity & Code Quality
+		"streetsidesoftware.code-spell-checker",
+		"usernamehw.errorlens",
+		"oderwat.indent-rainbow",
+		"wix.vscode-import-cost",
+		"christian-kohler.npm-intellisense",
+
+		// File & Project Management
+		"ms-vscode.hexeditor",
+		"redhat.vscode-yaml",
+		"ms-vscode.vscode-json",
+	];
+
+	// Linter-specific extensions
+	if (linter === "eslint") {
+		baseExtensions.push("dbaeumer.vscode-eslint");
+		baseExtensions.push("esbenp.prettier-vscode");
+	} else if (linter === "biome") {
+		baseExtensions.push("biomejs.biome");
+	}
+
+	// Database-specific extensions
+	if (orm === "drizzle") {
+		baseExtensions.push(
+			"mtxr.sqltools",
+			"mtxr.sqltools-driver-pg", // PostgreSQL driver
+		);
+	}
+
+	// Additional helpful extensions
+	baseExtensions.push(
+		"ms-vscode.vscode-json",
+		"redhat.vscode-yaml",
+		"ms-vscode.hexeditor",
+		"wix.vscode-import-cost",
+	);
+
+	return {
+		recommendations: baseExtensions,
+		unwantedRecommendations: [
+			// Conflicting formatters
+			"hookyqr.beautify",
+			"ms-vscode.vscode-typescript",
+		],
+	};
+}


### PR DESCRIPTION
# Pull Request

## Description
- Introduced a new option in the CLI to configure recommended VS Code workspace settings and extensions during project setup.
- Created a dedicated installer for VS Code that generates `settings.json` and `extensions.json` files based on selected linter and database provider.
- Enhanced the project scaffolding process to include VS Code configuration, improving the developer experience for new projects.

## Type of Change

- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style changes (formatting, etc.)
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Maintenance tasks
- [ ] `breaking`: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Affected Packages

- [ ] `@jsandy/rpc`
- [ ] `@jsandy/builder`
- [ ] `@jsandy/typescript-config`
- [x] `create-jsandy-app`
- [ ] `www`
- [ ] Root workspace/tooling
