### PR TITLE
Implement OpenAPI documentation generation for procedures

### DIFF
--- a/.changeset/fine-toys-train.md
+++ b/.changeset/fine-toys-train.md
@@ -1,0 +1,5 @@
+---
+"@jsandy/rpc": minor
+---
+
+Update to support exposure of open-api schemas

--- a/apps/www/src/components/table-of-contents.tsx
+++ b/apps/www/src/components/table-of-contents.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useTableOfContents } from "@/hooks/use-table-of-contents"; // Assuming this hook exists
-import { cn } from "@/lib/utils";
 import { slugify } from "@/lib/slugify";
+import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { type HTMLAttributes, useCallback, useEffect } from "react";
 
@@ -57,7 +57,7 @@ export const TableOfContents = ({
 			<p className="font-semibold text-sand-700 dark:text-sand-300 mb-3">
 				On this page
 			</p>
-			<ul className="space-y-2">
+			<ul className="space-y-2 md:space-y-0">
 				{allHeadings.map((heading) => {
 					const slug = slugify(heading.text);
 					if (!slug) return null;
@@ -66,9 +66,9 @@ export const TableOfContents = ({
 					return (
 						<li
 							key={slug}
-							className={cn("leading-relaxed", `ml-${(heading.level - 2) * 3}`)}
+							className="leading-relaxed"
+							style={{ marginLeft: `${(heading.level - 2) * 12}px` }}
 						>
-							{" "}
 							{/* Indent based on heading level */}
 							<Link
 								href={`#${slug}`}
@@ -77,10 +77,10 @@ export const TableOfContents = ({
 									onLinkClick?.();
 								}}
 								className={cn(
-									"block border-l-2 pl-3 py-0.5 transition-colors",
+									"block border-l-2 pl-3 py-0.5 transition-colors text-muted-foreground",
 									isVisible
-										? "border-sand-500 dark:border-sand-400 text-sand-700 dark:text-sand-300 font-medium"
-										: "border-transparent text-muted-foreground hover:text-foreground hover:border-sand-300 dark:hover:border-sand-600",
+										? "border-sand-500 dark:border-sand-400 dark:text-sand-300 font-medium"
+										: "border-transparent hover:text-foreground hover:border-sand-300 dark:hover:border-sand-600",
 								)}
 							>
 								{heading.text}

--- a/apps/www/src/config.ts
+++ b/apps/www/src/config.ts
@@ -35,6 +35,7 @@ export const DOCS_CONFIG: DocsConfig = {
 				"middleware",
 				"websockets",
 				"performance",
+				"open-api",
 			],
 		},
 		deploy: {

--- a/apps/www/src/docs/backend/app-router.mdx
+++ b/apps/www/src/docs/backend/app-router.mdx
@@ -3,7 +3,7 @@ title: AppRouter
 summary: The AppRouter in JSandy
 ---
 
-# appRouter Overview
+# AppRouter Overview
 
 The `appRouter` in JSandy:
 

--- a/apps/www/src/docs/backend/open-api.mdx
+++ b/apps/www/src/docs/backend/open-api.mdx
@@ -1,0 +1,418 @@
+---
+title: Documenting your API
+summary: Creating OpenAPI specifications with JSandy
+---
+
+# Documenting your API
+
+The `.describe()` method allows you to add comprehensive documentation metadata to your procedures, which can be used to generate OpenAPI specifications and enhance your API documentation.
+
+## Basic Usage
+
+Add documentation to any procedure using the `.describe()` method:
+
+```typescript
+import { z } from "zod/v4";
+import { jsandy } from "@jsandy/rpc";
+
+const { router, procedure } = jsandy.init();
+
+const userRouter = router({
+  getUser: procedure
+    .input(z.object({ id: z.string() }))
+    .describe({
+      description: "Retrieves a user by their unique identifier",
+      summary: "Get user by ID",
+      schema: z.object({
+        id: z.string(),
+        name: z.string(),
+        email: z.string(),
+        createdAt: z.date(),
+      }),
+      tags: ["users"],
+      operationId: "getUserById"
+    })
+    .get(({ input, c }) => {
+      // Implementation
+      return c.json({
+        id: input.id,
+        name: "John Doe",
+        email: "john@example.com",
+        createdAt: new Date()
+      });
+    })
+});
+```
+
+## Description Options
+
+The `.describe()` method accepts a comprehensive configuration object:
+
+```typescript
+interface ProcedureDescription {
+  /** Human-readable description of what this endpoint does */
+  description: string;
+
+  /** Optional summary for the endpoint (shorter than description) */
+  summary?: string;
+
+  /** Zod schema defining the expected output/response structure */
+  schema?: ZodAny;
+
+  /** Optional tags for grouping endpoints in documentation */
+  tags?: string[];
+
+  /** Optional operation ID for OpenAPI specification */
+  operationId?: string;
+
+  /** Whether this endpoint is deprecated */
+  deprecated?: boolean;
+
+  /** Additional OpenAPI metadata */
+  openapi?: {
+    /** Security requirements for this endpoint */
+    security?: Array<Record<string, string[]>>;
+
+    /** Additional response definitions */
+    responses?: Record<string, any>;
+
+    /** Request body examples */
+    examples?: Record<string, any>;
+  };
+}
+```
+
+## Working with Different HTTP Methods
+
+### GET Endpoints
+
+For GET endpoints, input schemas become query parameters in the OpenAPI spec:
+
+```typescript
+const searchPosts = procedure
+  .input(z.object({
+    query: z.string().min(1),
+    limit: z.number().min(1).max(100).default(10),
+    category: z.enum(["tech", "business", "lifestyle"]).optional()
+  }))
+  .describe({
+    description: "Search blog posts with pagination and filtering",
+    summary: "Search posts",
+    schema: z.object({
+      posts: z.array(z.object({
+        id: z.string(),
+        title: z.string(),
+        excerpt: z.string()
+      })),
+      pagination: z.object({
+        total: z.number(),
+        hasNext: z.boolean()
+      })
+    }),
+    tags: ["posts", "search"],
+    operationId: "searchPosts"
+  })
+  .get(({ input, c }) => {
+    // Implementation
+  });
+```
+
+### POST Endpoints
+
+For POST endpoints, input schemas become request body specifications:
+
+```typescript
+const createPost = procedure
+  .input(z.object({
+    title: z.string().min(1).max(200),
+    content: z.string().min(10),
+    tags: z.array(z.string()).optional(),
+    publishAt: z.date().optional()
+  }))
+  .describe({
+    description: "Creates a new blog post with the provided content",
+    summary: "Create blog post",
+    schema: z.object({
+      id: z.string(),
+      slug: z.string(),
+      status: z.enum(["draft", "published"]),
+      createdAt: z.date()
+    }),
+    tags: ["posts", "content"],
+    operationId: "createPost"
+  })
+  .post(({ input, c }) => {
+    // Implementation
+  });
+```
+
+## Advanced OpenAPI Features
+
+### Security Requirements
+
+Add authentication requirements to specific endpoints:
+
+```typescript
+const getAdminStats = procedure
+  .describe({
+    description: "Retrieves system statistics (admin only)",
+    summary: "Get admin statistics",
+    schema: z.object({
+      totalUsers: z.number(),
+      systemHealth: z.string()
+    }),
+    tags: ["admin"],
+    openapi: {
+      security: [{ bearerAuth: [] }]
+    }
+  })
+  .get(({ c }) => {
+    // Implementation
+  });
+```
+
+### Custom Error Responses
+
+Define additional response codes and schemas:
+
+```typescript
+const deleteUser = procedure
+  .input(z.object({ id: z.string() }))
+  .describe({
+    description: "Permanently deletes a user account",
+    summary: "Delete user",
+    tags: ["users"],
+    openapi: {
+      responses: {
+        404: {
+          description: "User not found",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  error: { type: "string", example: "USER_NOT_FOUND" },
+                  message: { type: "string" }
+                }
+              }
+            }
+          }
+        },
+        409: {
+          description: "Cannot delete user with active subscriptions",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  error: { type: "string", example: "USER_HAS_ACTIVE_SUBSCRIPTIONS" },
+                  subscriptions: { type: "array", items: { type: "string" } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+  .post(({ input, c }) => {
+    // Implementation
+  });
+```
+
+## Generating OpenAPI Documentation
+
+### Automatic OpenAPI Generation
+
+Use the built-in generator to create OpenAPI specifications:
+
+```typescript
+import { generateOpenAPISpec, addOpenAPIRoutes } from "@jsandy/rpc";
+import { Hono } from "hono";
+
+const app = new Hono();
+
+// Add automatic documentation routes
+await addOpenAPIRoutes(app, userRouter, {
+  title: "User Management API",
+  version: "1.0.0",
+  description: "Comprehensive user management with authentication",
+  servers: [
+    { url: "https://api.example.com", description: "Production" },
+    { url: "http://localhost:8080", description: "Development" }
+  ],
+  securitySchemes: {
+    bearerAuth: {
+      type: "http",
+      scheme: "bearer",
+      bearerFormat: "JWT"
+    }
+  }
+}, {
+  specPath: "/openapi.json",  // OpenAPI spec endpoint
+  docsPath: "/docs"           // Swagger UI endpoint
+});
+```
+
+### Manual OpenAPI Generation
+
+For more control, generate the spec manually:
+
+```typescript
+const openAPISpec = await generateOpenAPISpec(userRouter, {
+  title: "My API",
+  version: "2.0.0",
+  description: "API documentation",
+  basePath: "/api/v2"
+});
+
+// Serve the specification
+app.get("/api-spec.json", (c) => c.json(openAPISpec));
+
+// Custom Swagger UI with additional configuration
+app.get("/api-docs", (c) => {
+  const html = createSwaggerUI("/api-spec.json", "My API Docs");
+  return c.html(html);
+});
+```
+
+## Method Chaining
+
+The `.describe()` method works seamlessly with method chaining:
+
+```typescript
+const complexProcedure = procedure
+  .input(userInputSchema)           // Add input validation
+  .describe({                       // Add documentation
+    description: "Complex operation",
+    tags: ["complex"]
+  })
+  .use(authMiddleware)              // Add authentication
+  .use(rateLimitMiddleware)         // Add rate limiting
+  .get(({ input, ctx, c }) => {     // Define handler
+    // Implementation with full type safety
+  });
+```
+
+## Accessing Documentation Metadata
+
+Retrieve documentation metadata programmatically:
+
+```typescript
+// Get all operations with their descriptions
+const operations = userRouter.getAllOperations();
+
+// Get description for a specific operation
+const getUserDescription = userRouter.getOperationDescription("getUser");
+
+console.log(getUserDescription?.description);
+console.log(getUserDescription?.tags);
+```
+
+## Integration with @hono/zod-openapi
+
+The `.describe()` method is designed to work alongside `@hono/zod-openapi` for maximum compatibility:
+
+```typescript
+// Use enhanced Zod schemas with OpenAPI metadata
+import { z } from '@hono/zod-openapi';
+
+const UserSchema = z.object({
+  id: z.string().openapi({ example: '123' }),
+  name: z.string().openapi({ example: 'John Doe' }),
+  email: z.string().email().openapi({ example: 'john@example.com' })
+}).openapi('User');
+
+const getUserProcedure = procedure
+  .input(z.object({
+    id: z.string().openapi({
+      param: { name: 'id', in: 'path' },
+      example: '123'
+    })
+  }))
+  .describe({
+    description: "Get user with enhanced OpenAPI metadata",
+    schema: UserSchema,
+    tags: ["users"]
+  })
+  .get(({ input, c }) => {
+    // Implementation
+  });
+```
+
+## Best Practices
+
+### 1. Consistent Tagging
+
+Use consistent tags across related endpoints:
+
+```typescript
+const USER_TAGS = ["users"] as const;
+const ADMIN_TAGS = ["admin", "users"] as const;
+
+// Apply consistently
+const getUserProcedure = procedure.describe({
+  tags: USER_TAGS,
+  // ... other options
+});
+```
+
+### 2. Reusable Schemas
+
+Define schemas once and reuse them:
+
+```typescript
+const UserOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string(),
+  createdAt: z.date()
+});
+
+// Use in multiple procedures
+const getUser = procedure.describe({
+  schema: UserOutputSchema,
+  // ...
+});
+
+const updateUser = procedure.describe({
+  schema: UserOutputSchema,
+  // ...
+});
+```
+
+### 3. Meaningful Operation IDs
+
+Use clear, consistent operation IDs:
+
+```typescript
+// Good
+operationId: "getUserById"
+operationId: "createUserAccount"
+operationId: "updateUserProfile"
+
+// Avoid
+operationId: "get"
+operationId: "user1"
+operationId: "doStuff"
+```
+
+### 4. Comprehensive Error Documentation
+
+Document all possible error scenarios:
+
+```typescript
+.describe({
+  description: "Creates a new user account",
+  openapi: {
+    responses: {
+      400: { description: "Invalid input data" },
+      409: { description: "Email already exists" },
+      429: { description: "Rate limit exceeded" },
+      500: { description: "Internal server error" }
+    }
+  }
+})
+```
+
+This documentation system provides a powerful way to create self-documenting APIs that automatically generate comprehensive OpenAPI specifications while maintaining full type safety.

--- a/apps/www/src/docs/backend/open-api.mdx
+++ b/apps/www/src/docs/backend/open-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: Documenting your API
+title: Documenting
 summary: Creating OpenAPI specifications with JSandy
 ---
 
@@ -312,6 +312,9 @@ console.log(getUserDescription?.tags);
 ## Integration with @hono/zod-openapi
 
 The `.describe()` method is designed to work alongside `@hono/zod-openapi` for maximum compatibility:
+
+> **Note**: Most examples use `zod/v4` for standard schemas. The `@hono/zod-openapi` import provides additional OpenAPI-specific enhancements and should be used when you need advanced OpenAPI metadata on your schemas.
+
 
 ```typescript Integration with @hono/zod-openapi
 // Use enhanced Zod schemas with OpenAPI metadata

--- a/apps/www/src/docs/backend/open-api.mdx
+++ b/apps/www/src/docs/backend/open-api.mdx
@@ -11,7 +11,7 @@ The `.describe()` method allows you to add comprehensive documentation metadata 
 
 Add documentation to any procedure using the `.describe()` method:
 
-```typescript
+```typescript Example Procedure with .describe()
 import { z } from "zod/v4";
 import { jsandy } from "@jsandy/rpc";
 
@@ -48,7 +48,7 @@ const userRouter = router({
 
 The `.describe()` method accepts a comprehensive configuration object:
 
-```typescript
+```typescript Procedure Description Type
 interface ProcedureDescription {
   /** Human-readable description of what this endpoint does */
   description: string;
@@ -88,7 +88,7 @@ interface ProcedureDescription {
 
 For GET endpoints, input schemas become query parameters in the OpenAPI spec:
 
-```typescript
+```typescript GET Endpoint with .describe()
 const searchPosts = procedure
   .input(z.object({
     query: z.string().min(1),
@@ -121,7 +121,7 @@ const searchPosts = procedure
 
 For POST endpoints, input schemas become request body specifications:
 
-```typescript
+```typescript POST Endpoint with .describe()
 const createPost = procedure
   .input(z.object({
     title: z.string().min(1).max(200),
@@ -152,7 +152,7 @@ const createPost = procedure
 
 Add authentication requirements to specific endpoints:
 
-```typescript
+```typescript Security Requirements with .describe()
 const getAdminStats = procedure
   .describe({
     description: "Retrieves system statistics (admin only)",
@@ -175,7 +175,7 @@ const getAdminStats = procedure
 
 Define additional response codes and schemas:
 
-```typescript
+```typescript Custom Error Responses with .describe()
 const deleteUser = procedure
   .input(z.object({ id: z.string() }))
   .describe({
@@ -226,7 +226,7 @@ const deleteUser = procedure
 
 Use the built-in generator to create OpenAPI specifications:
 
-```typescript
+```typescript Automatic OpenAPI Generation
 import { generateOpenAPISpec, addOpenAPIRoutes } from "@jsandy/rpc";
 import { Hono } from "hono";
 
@@ -258,7 +258,7 @@ await addOpenAPIRoutes(app, userRouter, {
 
 For more control, generate the spec manually:
 
-```typescript
+```typescript Manual OpenAPI Generation
 const openAPISpec = await generateOpenAPISpec(userRouter, {
   title: "My API",
   version: "2.0.0",
@@ -280,7 +280,7 @@ app.get("/api-docs", (c) => {
 
 The `.describe()` method works seamlessly with method chaining:
 
-```typescript
+```typescript Method Chaining with .describe()
 const complexProcedure = procedure
   .input(userInputSchema)           // Add input validation
   .describe({                       // Add documentation
@@ -298,7 +298,7 @@ const complexProcedure = procedure
 
 Retrieve documentation metadata programmatically:
 
-```typescript
+```typescript Accessing Documentation Metadata
 // Get all operations with their descriptions
 const operations = userRouter.getAllOperations();
 
@@ -313,7 +313,7 @@ console.log(getUserDescription?.tags);
 
 The `.describe()` method is designed to work alongside `@hono/zod-openapi` for maximum compatibility:
 
-```typescript
+```typescript Integration with @hono/zod-openapi
 // Use enhanced Zod schemas with OpenAPI metadata
 import { z } from '@hono/zod-openapi';
 
@@ -339,80 +339,3 @@ const getUserProcedure = procedure
     // Implementation
   });
 ```
-
-## Best Practices
-
-### 1. Consistent Tagging
-
-Use consistent tags across related endpoints:
-
-```typescript
-const USER_TAGS = ["users"] as const;
-const ADMIN_TAGS = ["admin", "users"] as const;
-
-// Apply consistently
-const getUserProcedure = procedure.describe({
-  tags: USER_TAGS,
-  // ... other options
-});
-```
-
-### 2. Reusable Schemas
-
-Define schemas once and reuse them:
-
-```typescript
-const UserOutputSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  email: z.string(),
-  createdAt: z.date()
-});
-
-// Use in multiple procedures
-const getUser = procedure.describe({
-  schema: UserOutputSchema,
-  // ...
-});
-
-const updateUser = procedure.describe({
-  schema: UserOutputSchema,
-  // ...
-});
-```
-
-### 3. Meaningful Operation IDs
-
-Use clear, consistent operation IDs:
-
-```typescript
-// Good
-operationId: "getUserById"
-operationId: "createUserAccount"
-operationId: "updateUserProfile"
-
-// Avoid
-operationId: "get"
-operationId: "user1"
-operationId: "doStuff"
-```
-
-### 4. Comprehensive Error Documentation
-
-Document all possible error scenarios:
-
-```typescript
-.describe({
-  description: "Creates a new user account",
-  openapi: {
-    responses: {
-      400: { description: "Invalid input data" },
-      409: { description: "Email already exists" },
-      429: { description: "Rate limit exceeded" },
-      500: { description: "Internal server error" }
-    }
-  }
-})
-```
-
-This documentation system provides a powerful way to create self-documenting APIs that automatically generate comprehensive OpenAPI specifications while maintaining full type safety.

--- a/packages/rpc/src/__tests__/describe.test.ts
+++ b/packages/rpc/src/__tests__/describe.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { jsandy } from "@/j";
-import { generateOpenAPISpec } from "@/opeanapi";
+import { generateOpenAPISpec } from "@/openapi";
 import { z } from "zod/v4";
 
 const { router, procedure } = jsandy.init();
@@ -252,6 +252,7 @@ describe("OpenAPI generation", () => {
 		});
 
 		expect(spec.components?.schemas).toBeDefined();
+		console.log("Component Schema: ", JSON.stringify(spec, null, 2));
 		expect(Object.keys(spec.components?.schemas || {}).length).toBeGreaterThan(
 			0,
 		);
@@ -327,6 +328,8 @@ describe("OpenAPI generation", () => {
 			title: "Search API",
 			version: "1.0.0",
 		});
+
+		// console.log(JSON.stringify(spec, null, 2));
 
 		const searchOp = spec.paths["/search"].get;
 		expect(searchOp.parameters).toBeDefined();

--- a/packages/rpc/src/__tests__/describe.test.ts
+++ b/packages/rpc/src/__tests__/describe.test.ts
@@ -252,7 +252,6 @@ describe("OpenAPI generation", () => {
 		});
 
 		expect(spec.components?.schemas).toBeDefined();
-		console.log("Component Schema: ", JSON.stringify(spec, null, 2));
 		expect(Object.keys(spec.components?.schemas || {}).length).toBeGreaterThan(
 			0,
 		);
@@ -328,8 +327,6 @@ describe("OpenAPI generation", () => {
 			title: "Search API",
 			version: "1.0.0",
 		});
-
-		// console.log(JSON.stringify(spec, null, 2));
 
 		const searchOp = spec.paths["/search"].get;
 		expect(searchOp.parameters).toBeDefined();

--- a/packages/rpc/src/__tests__/describe.test.ts
+++ b/packages/rpc/src/__tests__/describe.test.ts
@@ -206,57 +206,6 @@ describe("OpenAPI generation", () => {
 		expect(healthOp.description).toBe("");
 	});
 
-	it("should handle complex nested schemas", async () => {
-		const complexRouter = router({
-			getProfile: procedure
-				.input(
-					z.object({
-						userId: z.string(),
-						includePreferences: z.boolean().optional(),
-					}),
-				)
-				.describe({
-					description: "Get user profile with optional preferences",
-					schema: z.object({
-						user: z.object({
-							id: z.string(),
-							profile: z.object({
-								name: z.string(),
-								avatar: z.string().url(),
-								preferences: z
-									.object({
-										theme: z.enum(["light", "dark"]),
-										notifications: z.boolean(),
-									})
-									.optional(),
-							}),
-						}),
-						metadata: z.object({
-							lastLogin: z.date(),
-							accountType: z.enum(["free", "premium", "enterprise"]),
-						}),
-					}),
-					tags: ["profile"],
-				})
-				.get(({ c }) =>
-					c.json({
-						user: { id: "1", profile: { name: "Test" } },
-						metadata: { lastLogin: new Date(), accountType: "free" },
-					}),
-				),
-		});
-
-		const spec = await generateOpenAPISpec(complexRouter, {
-			title: "Complex API",
-			version: "1.0.0",
-		});
-
-		expect(spec.components?.schemas).toBeDefined();
-		expect(Object.keys(spec.components?.schemas || {}).length).toBeGreaterThan(
-			0,
-		);
-	});
-
 	it("should handle OpenAPI-specific metadata", async () => {
 		const secureRouter = router({
 			adminData: procedure

--- a/packages/rpc/src/__tests__/describe.test.ts
+++ b/packages/rpc/src/__tests__/describe.test.ts
@@ -1,0 +1,468 @@
+import { describe, expect, it } from "bun:test";
+import { jsandy } from "@/j";
+import { generateOpenAPISpec } from "@/opeanapi";
+import { z } from "zod/v4";
+
+const { router, procedure } = jsandy.init();
+
+describe("Procedure .describe() functionality", () => {
+	it("should add description metadata to procedures", () => {
+		const testProcedure = procedure
+			.input(z.object({ id: z.string() }))
+			.describe({
+				description: "Test endpoint description",
+				summary: "Test endpoint",
+				schema: z.object({ result: z.string() }),
+				tags: ["test"],
+				operationId: "testOperation",
+			})
+			.get(({ input, c }) => c.json({ result: `Hello ${input.id}` }));
+
+		expect(testProcedure.description).toBeDefined();
+		expect(testProcedure.description?.description).toBe(
+			"Test endpoint description",
+		);
+		expect(testProcedure.description?.summary).toBe("Test endpoint");
+		expect(testProcedure.description?.tags).toEqual(["test"]);
+		expect(testProcedure.description?.operationId).toBe("testOperation");
+	});
+
+	it("should work without description metadata", () => {
+		const simpleProcedure = procedure
+			.input(z.object({ name: z.string() }))
+			.get(({ input, c }) => c.json({ greeting: `Hello ${input.name}` }));
+
+		expect(simpleProcedure.description).toBeUndefined();
+		expect(simpleProcedure.type).toBe("get");
+	});
+
+	it("should preserve description through method chaining", () => {
+		const chainedProcedure = procedure
+			.describe({
+				description: "Chained procedure",
+				tags: ["chained"],
+			})
+			.input(z.object({ value: z.number() }))
+			.get(({ input, c }) => c.json({ doubled: input.value * 2 }));
+
+		expect(chainedProcedure.description?.description).toBe("Chained procedure");
+		expect(chainedProcedure.description?.tags).toEqual(["chained"]);
+	});
+
+	it("should work with POST operations", () => {
+		const postProcedure = procedure
+			.input(z.object({ name: z.string(), email: z.string() }))
+			.describe({
+				description: "Create a new resource",
+				summary: "Create resource",
+				schema: z.object({ id: z.string(), created: z.boolean() }),
+			})
+			.post(({ c }) => c.json({ id: "123", created: true }));
+
+		expect(postProcedure.type).toBe("post");
+		expect(postProcedure.description?.description).toBe(
+			"Create a new resource",
+		);
+	});
+
+	it("should work with WebSocket operations", () => {
+		const wsProcedure = procedure
+			.incoming(z.object({ message: z.string() }))
+			.outgoing(z.object({ response: z.string() }))
+			.describe({
+				description: "WebSocket chat endpoint",
+				tags: ["websocket", "chat"],
+			})
+			.ws(() => ({
+				onConnect: async () => console.log("Connected"),
+			}));
+
+		expect(wsProcedure.type).toBe("ws");
+		expect(wsProcedure.description?.description).toBe(
+			"WebSocket chat endpoint",
+		);
+		expect(wsProcedure.description?.tags).toEqual(["websocket", "chat"]);
+	});
+
+	it("should store operations in router metadata", () => {
+		const testRouter = router({
+			getTest: procedure
+				.input(z.object({ id: z.string() }))
+				.describe({
+					description: "Get test data",
+					operationId: "getTest",
+				})
+				.get(({ input, c }) => c.json({ id: input.id })),
+			createTest: procedure
+				.input(z.object({ name: z.string() }))
+				.post(({ c }) => c.json({ created: true })),
+		});
+
+		const operations = testRouter.getAllOperations();
+		expect(Object.keys(operations)).toContain("getTest");
+		expect(Object.keys(operations)).toContain("createTest");
+
+		const getTestDescription = testRouter.getOperationDescription("getTest");
+		expect(getTestDescription?.description).toBe("Get test data");
+		expect(getTestDescription?.operationId).toBe("getTest");
+
+		const createTestDescription =
+			testRouter.getOperationDescription("createTest");
+		expect(createTestDescription).toBeUndefined();
+	});
+});
+
+describe("OpenAPI generation", () => {
+	it("should generate OpenAPI spec from described procedures", async () => {
+		const documentedRouter = router({
+			getUser: procedure
+				.input(z.object({ id: z.string() }))
+				.describe({
+					description: "Get user by ID",
+					summary: "Get user",
+					schema: z.object({
+						id: z.string(),
+						name: z.string(),
+						email: z.string(),
+					}),
+					tags: ["users"],
+					operationId: "getUser",
+				})
+				.get(({ input, c }) =>
+					c.json({ id: input.id, name: "Test", email: "test@example.com" }),
+				),
+
+			createUser: procedure
+				.input(
+					z.object({
+						name: z.string(),
+						email: z.string(),
+					}),
+				)
+				.describe({
+					description: "Create a new user",
+					summary: "Create user",
+					schema: z.object({
+						id: z.string(),
+						created: z.boolean(),
+					}),
+					tags: ["users"],
+				})
+				.post(({ c }) => c.json({ id: "123", created: true })),
+		});
+
+		const spec = await generateOpenAPISpec(documentedRouter, {
+			title: "Test API",
+			version: "1.0.0",
+			description: "Test API for validation",
+		});
+
+		// Verify basic structure
+		expect(spec.openapi).toBe("3.0.0");
+		expect(spec.info.title).toBe("Test API");
+		expect(spec.info.version).toBe("1.0.0");
+		expect(spec.paths).toBeDefined();
+
+		// Verify that operations are included
+		expect(spec.paths["/getUser"]).toBeDefined();
+		expect(spec.paths["/createUser"]).toBeDefined();
+
+		// Verify GET operation
+		const getUserOperation = spec.paths["/getUser"].get;
+		expect(getUserOperation).toBeDefined();
+		expect(getUserOperation.summary).toBe("Get user");
+		expect(getUserOperation.description).toBe("Get user by ID");
+		expect(getUserOperation.operationId).toBe("getUser");
+		expect(getUserOperation.tags).toEqual(["users"]);
+
+		// Verify POST operation
+		const createUserOperation = spec.paths["/createUser"].post;
+		expect(createUserOperation).toBeDefined();
+		expect(createUserOperation.summary).toBe("Create user");
+		expect(createUserOperation.description).toBe("Create a new user");
+		expect(createUserOperation.tags).toEqual(["users"]);
+
+		// Verify tags are collected
+		expect(spec.tags).toEqual([{ name: "users" }]);
+	});
+
+	it("should handle procedures without descriptions", async () => {
+		const simpleRouter = router({
+			health: procedure.get(({ c }) => c.json({ status: "ok" })),
+			ping: procedure.post(({ c }) => c.json({ pong: true })),
+		});
+
+		const spec = await generateOpenAPISpec(simpleRouter, {
+			title: "Simple API",
+			version: "1.0.0",
+		});
+
+		expect(spec.paths["/health"]).toBeDefined();
+		expect(spec.paths["/ping"]).toBeDefined();
+
+		// Should have default descriptions
+		const healthOp = spec.paths["/health"].get;
+		expect(healthOp.summary).toBe("GET operation");
+		expect(healthOp.description).toBe("");
+	});
+
+	it("should handle complex nested schemas", async () => {
+		const complexRouter = router({
+			getProfile: procedure
+				.input(
+					z.object({
+						userId: z.string(),
+						includePreferences: z.boolean().optional(),
+					}),
+				)
+				.describe({
+					description: "Get user profile with optional preferences",
+					schema: z.object({
+						user: z.object({
+							id: z.string(),
+							profile: z.object({
+								name: z.string(),
+								avatar: z.string().url(),
+								preferences: z
+									.object({
+										theme: z.enum(["light", "dark"]),
+										notifications: z.boolean(),
+									})
+									.optional(),
+							}),
+						}),
+						metadata: z.object({
+							lastLogin: z.date(),
+							accountType: z.enum(["free", "premium", "enterprise"]),
+						}),
+					}),
+					tags: ["profile"],
+				})
+				.get(({ c }) =>
+					c.json({
+						user: { id: "1", profile: { name: "Test" } },
+						metadata: { lastLogin: new Date(), accountType: "free" },
+					}),
+				),
+		});
+
+		const spec = await generateOpenAPISpec(complexRouter, {
+			title: "Complex API",
+			version: "1.0.0",
+		});
+
+		expect(spec.components?.schemas).toBeDefined();
+		expect(Object.keys(spec.components?.schemas || {}).length).toBeGreaterThan(
+			0,
+		);
+	});
+
+	it("should handle OpenAPI-specific metadata", async () => {
+		const secureRouter = router({
+			adminData: procedure
+				.describe({
+					description: "Get admin-only data",
+					summary: "Admin data",
+					tags: ["admin"],
+					openapi: {
+						security: [{ bearerAuth: [] }],
+						responses: {
+							403: {
+								description: "Forbidden - Admin access required",
+								content: {
+									"application/json": {
+										schema: {
+											type: "object",
+											properties: {
+												error: { type: "string" },
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				})
+				.get(({ c }) => c.json({ adminData: "secret" })),
+		});
+
+		const spec = await generateOpenAPISpec(secureRouter, {
+			title: "Secure API",
+			version: "1.0.0",
+			securitySchemes: {
+				bearerAuth: {
+					type: "http",
+					scheme: "bearer",
+				},
+			},
+		});
+
+		const adminOp = spec.paths["/adminData"].get;
+		expect(adminOp.security).toEqual([{ bearerAuth: [] }]);
+		expect(adminOp.responses[403]).toBeDefined();
+		expect(adminOp.responses[403].description).toBe(
+			"Forbidden - Admin access required",
+		);
+	});
+
+	it("should handle query parameters for GET requests", async () => {
+		const searchRouter = router({
+			search: procedure
+				.input(
+					z.object({
+						query: z.string().min(1),
+						limit: z.number().min(1).max(100).default(10),
+						offset: z.number().min(0).default(0),
+						sortBy: z.enum(["name", "date", "relevance"]).optional(),
+					}),
+				)
+				.describe({
+					description: "Search endpoint with pagination",
+					tags: ["search"],
+				})
+				.get(({ c }) => c.json({ results: [], total: 0 })),
+		});
+
+		const spec = await generateOpenAPISpec(searchRouter, {
+			title: "Search API",
+			version: "1.0.0",
+		});
+
+		const searchOp = spec.paths["/search"].get;
+		expect(searchOp.parameters).toBeDefined();
+		expect(searchOp.parameters.length).toBe(4);
+
+		const queryParam = searchOp.parameters.find((p: any) => p.name === "query");
+		expect(queryParam).toBeDefined();
+		expect(queryParam.in).toBe("query");
+		expect(queryParam.required).toBe(true);
+
+		const limitParam = searchOp.parameters.find((p: any) => p.name === "limit");
+		expect(limitParam.required).toBe(false); // has default value
+	});
+
+	it("should handle request body for POST requests", async () => {
+		const createRouter = router({
+			createPost: procedure
+				.input(
+					z.object({
+						title: z.string().min(1).max(200),
+						content: z.string().min(10),
+						tags: z.array(z.string()).optional(),
+						publishedAt: z.date().optional(),
+					}),
+				)
+				.describe({
+					description: "Create a new blog post",
+					schema: z.object({
+						id: z.string(),
+						slug: z.string(),
+						createdAt: z.date(),
+					}),
+					tags: ["posts"],
+				})
+				.post(({ c }) =>
+					c.json({ id: "1", slug: "test-post", createdAt: new Date() }),
+				),
+		});
+
+		const spec = await generateOpenAPISpec(createRouter, {
+			title: "Blog API",
+			version: "1.0.0",
+		});
+
+		const createOp = spec.paths["/createPost"].post;
+		expect(createOp.requestBody).toBeDefined();
+		expect(createOp.requestBody.required).toBe(true);
+		expect(createOp.requestBody.content["application/json"]).toBeDefined();
+		expect(
+			createOp.requestBody.content["application/json"].schema,
+		).toBeDefined();
+	});
+});
+
+describe("Integration with existing functionality", () => {
+	it("should work with middleware", () => {
+		const { middleware } = jsandy.init();
+
+		const authMiddleware = middleware(async ({ next }) => {
+			return next({ user: { id: "123" } });
+		});
+
+		const protectedProcedure = procedure
+			.use(authMiddleware)
+			.input(z.object({ id: z.string() }))
+			.describe({
+				description: "Protected endpoint requiring authentication",
+				tags: ["protected"],
+			})
+			.get(({ ctx, input, c }) => {
+				return c.json({ userId: ctx.user.id, requestedId: input.id });
+			});
+
+		expect(protectedProcedure.description?.description).toBe(
+			"Protected endpoint requiring authentication",
+		);
+		expect(protectedProcedure.middlewares.length).toBeGreaterThan(1); // SuperJSON + auth middleware
+	});
+
+	it("should work with router merging", () => {
+		const userRouter = router({
+			get: procedure
+				.describe({
+					description: "Get user",
+					tags: ["users"],
+				})
+				.get(({ c }) => c.json({ user: "data" })),
+		});
+
+		const postRouter = router({
+			get: procedure
+				.describe({
+					description: "Get post",
+					tags: ["posts"],
+				})
+				.get(({ c }) => c.json({ post: "data" })),
+		});
+
+		const api = router();
+		const merged = jsandy.init().mergeRouters(api, {
+			users: userRouter,
+			posts: postRouter,
+		});
+
+		expect(merged._metadata.subRouters["/api/users"]).toBeDefined();
+		expect(merged._metadata.subRouters["/api/posts"]).toBeDefined();
+	});
+
+	it("should preserve type safety", () => {
+		// This test mainly ensures compilation works correctly
+		const typedProcedure = procedure
+			.input(
+				z.object({
+					id: z.string(),
+					count: z.number(),
+				}),
+			)
+			.describe({
+				description: "Type-safe procedure",
+				schema: z.object({
+					result: z.string(),
+					processedCount: z.number(),
+				}),
+			})
+			.get(({ input, c }) => {
+				// TypeScript should infer input types correctly
+				const id: string = input.id;
+				const count: number = input.count;
+
+				return c.json({
+					result: `Processed ${id}`,
+					processedCount: count * 2,
+				});
+			});
+
+		expect(typedProcedure.type).toBe("get");
+		expect(typedProcedure.description?.description).toBe("Type-safe procedure");
+	});
+});

--- a/packages/rpc/src/__tests__/merge-routers.test.ts
+++ b/packages/rpc/src/__tests__/merge-routers.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { mergeRouters } from "../merge-routers";
-import { Router } from "../router";
+import type { Hono } from "hono";
 import { z } from "zod/v4";
 import { jsandy } from "..";
-import type { Hono } from "hono";
+import { mergeRouters } from "../merge-routers";
+import { Router } from "../router";
 
 const j = jsandy.init();
 const procedure = j.procedure;

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -7,3 +7,4 @@ export * from "./router";
 export * from "./client";
 export * from "./dynamic";
 export * from "./schemas";
+export * from "./openapi";

--- a/packages/rpc/src/merge-routers.ts
+++ b/packages/rpc/src/merge-routers.ts
@@ -79,6 +79,7 @@ export function mergeRouters<
 		config: {},
 		procedures: {},
 		registeredPaths: [],
+		operations: {},
 	};
 
 	// Process each router in the collection

--- a/packages/rpc/src/opeanapi.ts
+++ b/packages/rpc/src/opeanapi.ts
@@ -1,0 +1,456 @@
+import { toJSONSchema } from "zod/v4";
+import type { JSONSchema } from "zod/v4/core";
+import type { ProcedureDescription } from "./procedure";
+import type { Router } from "./router";
+import type { ZodAny } from "./types";
+
+/**
+ * OpenAPI specification structure
+ */
+export interface OpenAPISpec {
+	openapi: string;
+	info: {
+		title: string;
+		version: string;
+		description?: string;
+	};
+	servers?: Array<{
+		url: string;
+		description?: string;
+	}>;
+	paths: Record<string, any>;
+	components?: {
+		schemas?: Record<string, any>;
+		securitySchemes?: Record<string, any>;
+	};
+	tags?: Array<{
+		name: string;
+		description?: string;
+	}>;
+}
+
+/**
+ * Configuration for OpenAPI generation
+ */
+export interface OpenAPIConfig {
+	/** API title */
+	title: string;
+	/** API version */
+	version: string;
+	/** API description */
+	description?: string;
+	/** Server configurations */
+	servers?: Array<{
+		url: string;
+		description?: string;
+	}>;
+	/** Base path for all routes */
+	basePath?: string;
+	/** Security schemes */
+	securitySchemes?: Record<string, any>;
+}
+
+/**
+ * Generates OpenAPI documentation from JSandy routers with procedure descriptions
+ *
+ * @param router - The router instance to generate documentation from
+ * @param config - Configuration for the OpenAPI specification
+ * @returns Complete OpenAPI specification object
+ *
+ * @example
+ * ```typescript
+ * import { generateOpenAPISpec } from '@jsandy/rpc';
+ *
+ * const spec = await generateOpenAPISpec(appRouter, {
+ *   title: 'My API',
+ *   version: '1.0.0',
+ *   description: 'A comprehensive API built with JSandy',
+ *   servers: [
+ *     { url: 'https://api.example.com', description: 'Production' },
+ *     { url: 'http://localhost:8080', description: 'Development' }
+ *   ]
+ * });
+ *
+ * // Use with Hono to serve documentation
+ * app.get('/openapi.json', (c) => c.json(spec));
+ * ```
+ */
+export async function generateOpenAPISpec(
+	router: Router,
+	config: OpenAPIConfig,
+): Promise<OpenAPISpec> {
+	const spec: OpenAPISpec = {
+		openapi: "3.0.0",
+		info: {
+			title: config.title,
+			version: config.version,
+			description: config.description,
+		},
+		servers: config.servers,
+		paths: {},
+		components: {
+			schemas: {},
+			securitySchemes: config.securitySchemes,
+		},
+		tags: [],
+	};
+
+	// Track unique tags and schemas
+	const tags = new Set<string>();
+	const schemas = new Map<string, any>();
+
+	await processRouter(router, "", spec, tags, schemas, config.basePath);
+
+	// Add collected tags to spec
+	spec.tags = Array.from(tags).map((tag) => ({ name: tag }));
+
+	// Add collected schemas to spec
+	if (schemas.size > 0) {
+		// biome-ignore lint/style/noNonNullAssertion: We just checked that schemas.size > 0
+		spec.components!.schemas = Object.fromEntries(schemas);
+	}
+
+	return spec;
+}
+
+/**
+ * Recursively processes a router and its sub-routers to extract OpenAPI paths
+ */
+async function processRouter(
+	router: Router | Promise<Router>,
+	basePath: string,
+	spec: OpenAPISpec,
+	tags: Set<string>,
+	schemas: Map<string, any>,
+	configBasePath?: string,
+): Promise<void> {
+	// Resolve router if it's a promise (dynamic import)
+	const resolvedRouter = await Promise.resolve(router);
+	const metadata = resolvedRouter._metadata;
+
+	// Process procedures at current level
+	if (metadata.procedures) {
+		for (const [procedureName, procedure] of Object.entries(
+			metadata.procedures,
+		)) {
+			const fullPath = `${basePath}/${procedureName}`;
+			const pathKey = (configBasePath || "") + fullPath;
+
+			// Skip WebSocket procedures for now (OpenAPI doesn't have great WebSocket support)
+			if (procedure.type === "ws") {
+				continue;
+			}
+
+			// Initialize path object if it doesn't exist
+			if (!spec.paths[pathKey]) {
+				spec.paths[pathKey] = {};
+			}
+
+			// Get the actual operation from the router to access description
+			const operation = findOperationInRouter(resolvedRouter, procedureName);
+			const description = operation?.description;
+
+			// Process GET operations
+			if (procedure.type === "get") {
+				spec.paths[pathKey].get = createOperationSpec(
+					procedure,
+					description,
+					tags,
+					schemas,
+				);
+			}
+
+			// Process POST operations
+			if (procedure.type === "post") {
+				spec.paths[pathKey].post = createOperationSpec(
+					procedure,
+					description,
+					tags,
+					schemas,
+				);
+			}
+		}
+	}
+
+	// Recursively process sub-routers
+	if (metadata.subRouters) {
+		for (const [routePath, subRouter] of Object.entries(metadata.subRouters)) {
+			const newPath = `${basePath}${routePath}`;
+			await processRouter(
+				subRouter,
+				newPath,
+				spec,
+				tags,
+				schemas,
+				configBasePath,
+			);
+		}
+	}
+}
+
+/**
+ * Finds an operation in the router to access its description metadata
+ */
+function findOperationInRouter(router: Router, procedureName: string): any {
+	// This is a bit of a hack since we need to access the original operations
+	// In a real implementation, you might want to store this differently
+	// For now, we'll try to access it through the router's internal structure
+	try {
+		return router._metadata.operations?.[procedureName];
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Creates an OpenAPI operation specification from a procedure
+ */
+function createOperationSpec(
+	procedure: any,
+	description: ProcedureDescription | undefined,
+	tags: Set<string>,
+	schemas: Map<string, any>,
+): OpenAPISpec["paths"][string] {
+	const operation: OpenAPISpec["paths"][string] = {
+		summary:
+			description?.summary || `${procedure.type.toUpperCase()} operation`,
+		description: description?.description || "",
+		operationId: description?.operationId,
+		deprecated: description?.deprecated || false,
+		tags: description?.tags || [],
+		responses: {
+			200: {
+				description: "Successful response",
+				content: {
+					"application/json": {
+						schema: { type: "object" },
+					},
+				},
+			},
+		},
+	};
+
+	// Add tags to the global tag set
+	if (description?.tags) {
+		for (const tag of description.tags) {
+			tags.add(tag);
+		}
+	}
+
+	// Handle input schema (query parameters for GET, request body for POST)
+	if (procedure.schema) {
+		const inputSchema = convertZodToOpenAPI(procedure.schema, schemas);
+
+		if (procedure.type === "get") {
+			// For GET requests, convert schema properties to query parameters
+			operation.parameters = createQueryParameters(inputSchema);
+		} else if (procedure.type === "post") {
+			// For POST requests, use schema as request body
+			operation.requestBody = {
+				required: true,
+				content: {
+					"application/json": {
+						schema: inputSchema,
+					},
+				},
+			};
+		}
+	}
+
+	// Handle output schema from description
+	if (description?.schema) {
+		const outputSchema = convertZodToOpenAPI(description.schema, schemas);
+		operation.responses[200].content["application/json"].schema = outputSchema;
+	}
+
+	// Add additional OpenAPI metadata from description
+	if (description?.openapi) {
+		if (description.openapi.security) {
+			operation.security = description.openapi.security;
+		}
+		if (description.openapi.responses) {
+			Object.assign(operation.responses, description.openapi.responses);
+		}
+	}
+
+	// Add error responses
+	operation.responses[400] = {
+		description: "Bad Request",
+		content: {
+			"application/json": {
+				schema: {
+					type: "object",
+					properties: {
+						error: { type: "string" },
+						message: { type: "string" },
+					},
+				},
+			},
+		},
+	};
+
+	operation.responses[500] = {
+		description: "Internal Server Error",
+		content: {
+			"application/json": {
+				schema: {
+					type: "object",
+					properties: {
+						error: { type: "string" },
+						message: { type: "string" },
+					},
+				},
+			},
+		},
+	};
+
+	return operation;
+}
+
+/**
+ * Converts a Zod schema to OpenAPI JSON Schema format
+ */
+function convertZodToOpenAPI(
+	zodSchema: ZodAny,
+	schemas: Map<string, any>,
+): JSONSchema.BaseSchema {
+	try {
+		// We cannot convert zod v3 schemas to openapi, so we return an empty object
+		if (!("_zod" in zodSchema)) {
+			return { type: "object" };
+		}
+		const jsonSchema = toJSONSchema(zodSchema);
+
+		// Generate a schema name if it has a title or generate one
+		const schemaName = jsonSchema.title || `Schema_${schemas.size + 1}`;
+
+		// Store reusable schemas in components
+		if (jsonSchema.type === "object" && jsonSchema.properties) {
+			schemas.set(schemaName, jsonSchema);
+			return { $ref: `#/components/schemas/${schemaName}` };
+		}
+
+		return jsonSchema;
+	} catch (error) {
+		console.warn("Failed to convert Zod schema to OpenAPI:", error);
+		return { type: "object" };
+	}
+}
+
+/**
+ * Creates OpenAPI query parameters from a JSON schema
+ */
+function createQueryParameters(schema: any): any[] {
+	if (!schema.properties) {
+		return [];
+	}
+
+	return Object.entries(schema.properties).map(
+		([name, propSchema]: [string, any]) => ({
+			name,
+			in: "query",
+			required: schema.required?.includes(name) || false,
+			schema: propSchema,
+			description: propSchema.description,
+		}),
+	);
+}
+
+/**
+ * Creates a Swagger UI HTML page for API documentation
+ *
+ * @param specUrl - URL where the OpenAPI spec JSON is served
+ * @param title - Title for the documentation page
+ * @returns HTML string for Swagger UI
+ *
+ * @example
+ * ```typescript
+ * // Serve Swagger UI
+ * app.get('/docs', (c) => {
+ *   const html = createSwaggerUI('/openapi.json', 'My API Documentation');
+ *   return c.html(html);
+ * });
+ * ```
+ */
+export function createSwaggerUI(
+	specUrl: string,
+	title = "API Documentation",
+): string {
+	return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${title}</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui.css" />
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui-bundle.js" crossorigin></script>
+  <script>
+    window.onload = () => {
+      window.ui = SwaggerUIBundle({
+        url: '${specUrl}',
+        dom_id: '#swagger-ui',
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIBundle.presets.standalone,
+        ],
+        layout: "StandaloneLayout",
+      });
+    };
+  </script>
+</body>
+</html>`;
+}
+
+/**
+ * Helper function to add OpenAPI documentation routes to a Hono app
+ *
+ * @param app - Hono application instance
+ * @param router - JSandy router to generate docs from
+ * @param config - OpenAPI configuration
+ * @param options - Additional options for documentation routes
+ *
+ * @example
+ * ```typescript
+ * import { Hono } from 'hono';
+ * import { addOpenAPIRoutes } from '@jsandy/rpc';
+ *
+ * const app = new Hono();
+ *
+ * // Add OpenAPI documentation routes
+ * await addOpenAPIRoutes(app, userRouter, {
+ *   title: 'User API',
+ *   version: '1.0.0',
+ *   description: 'API for managing users'
+ * }, {
+ *   specPath: '/api-spec.json',
+ *   docsPath: '/api-docs'
+ * });
+ * ```
+ */
+export async function addOpenAPIRoutes(
+	app: any, // Hono instance
+	router: Router,
+	config: OpenAPIConfig,
+	options: {
+		specPath?: string;
+		docsPath?: string;
+	} = {},
+): Promise<void> {
+	const { specPath = "/openapi.json", docsPath = "/docs" } = options;
+
+	// Generate the OpenAPI specification
+	const spec = await generateOpenAPISpec(router, config);
+
+	// Add route for serving the OpenAPI JSON spec
+	app.get(specPath, (c: any) => c.json(spec));
+
+	// Add route for serving Swagger UI documentation
+	app.get(docsPath, (c: any) => {
+		const html = createSwaggerUI(specPath, config.title);
+		return c.html(html);
+	});
+}

--- a/packages/rpc/src/openapi.ts
+++ b/packages/rpc/src/openapi.ts
@@ -193,8 +193,6 @@ async function processRouter(
  */
 function findOperationInRouter(router: Router, procedureName: string): any {
 	// This is a bit of a hack since we need to access the original operations
-	// In a real implementation, you might want to store this differently
-	// For now, we'll try to access it through the router's internal structure
 	try {
 		return router._metadata.operations?.[procedureName];
 	} catch {
@@ -613,7 +611,7 @@ export function toJSONSchemaWithDate<T extends ZodType>(
 		override: (ctx) => {
 			// Check if this is a date type
 			const def = ctx.zodSchema._zod?.def;
-			if (def.type === "date") {
+			if (def?.type === "date") {
 				// Convert z.date() to ISO datetime string format
 				ctx.jsonSchema.type = "string";
 				ctx.jsonSchema.format = "date-time";

--- a/packages/rpc/src/openapi.ts
+++ b/packages/rpc/src/openapi.ts
@@ -133,7 +133,7 @@ async function processRouter(
 		for (const [procedureName, procedure] of Object.entries(
 			metadata.procedures,
 		)) {
-			const fullPath = `${basePath}/${procedureName}`;
+			const fullPath = `${basePath.replace(/\/$/, "")}/${procedureName}`;
 			const pathKey = (configBasePath || "") + fullPath;
 
 			// Skip WebSocket procedures for now (OpenAPI doesn't have great WebSocket support)
@@ -315,6 +315,7 @@ function convertZodToOpenAPI(
 	try {
 		// We cannot convert zod v3 schemas to openapi, so we return an empty object
 		if (!("_zod" in zodSchema) && !("$schema" in zodSchema)) {
+			console.warn("Zod v3 schemas cannot be converted to OpenAPI:", zodSchema);
 			return { type: "object" };
 		}
 		let jsonSchema: JSONSchema.BaseSchema;

--- a/packages/rpc/src/procedure.ts
+++ b/packages/rpc/src/procedure.ts
@@ -161,7 +161,7 @@ export class Procedure<
 	 */
 	describe(description: ProcedureDescription) {
 		return new Procedure<E, Ctx, InputSchema, Incoming, Outgoing>(
-			this.middlewares,
+			[...this.middlewares], // clone to isolate
 			this.inputSchema,
 			this.incomingSchema,
 			this.outgoingSchema,

--- a/packages/rpc/src/procedure.ts
+++ b/packages/rpc/src/procedure.ts
@@ -23,7 +23,7 @@ import type {
  */
 export interface ProcedureDescription {
 	/** Human-readable description of what this endpoint does */
-	description: string;
+	description?: string;
 	/** Optional summary for the endpoint (shorter than description) */
 	summary?: string;
 	/** Zod schema defining the expected output/response structure */
@@ -264,9 +264,7 @@ export class Procedure<
 			c: ContextWithSuperJSON<E>;
 			input: InferZodType<InputSchema>;
 		}) => Return,
-	): GetOperation<InputSchema, ReturnType<typeof handler>, E> & {
-		description?: ProcedureDescription;
-	} {
+	): GetOperation<InputSchema, ReturnType<typeof handler>, E> {
 		return {
 			type: "get",
 			schema: this.inputSchema as
@@ -297,9 +295,7 @@ export class Procedure<
 			c: ContextWithSuperJSON<E>;
 			input: InferZodType<InputSchema>;
 		}) => Return,
-	): GetOperation<InputSchema, Return, E> & {
-		description?: ProcedureDescription;
-	} {
+	): GetOperation<InputSchema, Return, E> {
 		return this.get(handler);
 	}
 
@@ -323,9 +319,7 @@ export class Procedure<
 			c: ContextWithSuperJSON<E>;
 			input: InferZodType<InputSchema>;
 		}) => Return,
-	): PostOperation<InputSchema, ReturnType<typeof handler>, E> & {
-		description?: ProcedureDescription;
-	} {
+	): PostOperation<InputSchema, ReturnType<typeof handler>, E> {
 		return {
 			type: "post",
 			schema: this.inputSchema as
@@ -356,9 +350,7 @@ export class Procedure<
 			c: ContextWithSuperJSON<E>;
 			input: InferZodType<InputSchema>;
 		}) => Return,
-	): PostOperation<InputSchema, Return, E> & {
-		description?: ProcedureDescription;
-	} {
+	): PostOperation<InputSchema, Return, E> {
 		return this.post(handler);
 	}
 
@@ -384,9 +376,7 @@ export class Procedure<
 		}) => OptionalPromise<
 			WebSocketHandler<InferZodType<Incoming>, InferZodType<Outgoing>>
 		>,
-	): WebSocketOperation<InferZodType<Incoming>, InferZodType<Outgoing>, E> & {
-		description?: ProcedureDescription;
-	} {
+	): WebSocketOperation<InferZodType<Incoming>, InferZodType<Outgoing>, E> {
 		return {
 			type: "ws",
 			outputFormat: "ws",

--- a/packages/rpc/src/procedure.ts
+++ b/packages/rpc/src/procedure.ts
@@ -1,6 +1,8 @@
-import superjson from "superjson";
 import type { Env } from "hono/types";
 import type { StatusCode } from "hono/utils/http-status";
+import superjson from "superjson";
+import type { ZodType as ZodV3Type } from "zod";
+import type { ZodType as ZodV4Type } from "zod/v4";
 import type { IO } from "./sockets";
 import type {
 	ContextWithSuperJSON,
@@ -14,12 +16,38 @@ import type {
 	WebSocketOperation,
 	ZodAny,
 } from "./types";
-import type { ZodType as ZodV3Type } from "zod";
-import type { ZodType as ZodV4Type } from "zod/v4";
 
 /**
- * Procedure class for building type-safe API endpoints with middleware chaining
- * Provides a fluent interface for configuring input validation, middleware, and handlers
+ * Description configuration for procedures
+ * Provides OpenAPI documentation metadata for endpoints
+ */
+export interface ProcedureDescription {
+	/** Human-readable description of what this endpoint does */
+	description: string;
+	/** Optional summary for the endpoint (shorter than description) */
+	summary?: string;
+	/** Zod schema defining the expected output/response structure */
+	schema?: ZodAny;
+	/** Optional tags for grouping endpoints in documentation */
+	tags?: string[];
+	/** Optional operation ID for OpenAPI specification */
+	operationId?: string;
+	/** Whether this endpoint is deprecated */
+	deprecated?: boolean;
+	/** Additional OpenAPI metadata */
+	openapi?: {
+		/** Security requirements for this endpoint */
+		security?: Array<Record<string, string[]>>;
+		/** Additional response definitions */
+		responses?: Record<string, any>;
+		/** Request body examples */
+		examples?: Record<string, any>;
+	};
+}
+
+/**
+ * Procedure class for building type-safe API endpoints with middleware chaining and OpenAPI documentation
+ * Provides a fluent interface for configuring input validation, middleware, handlers, and documentation
  *
  * @template E - Environment type extending Hono's Env, defaults to Env
  * @template Ctx - Context object type accumulated from middleware, defaults to Record<string, unknown>
@@ -45,6 +73,9 @@ export class Procedure<
 
 	/** Zod schema for validating outgoing WebSocket messages */
 	private readonly outgoingSchema?: Outgoing;
+
+	/** Description metadata for OpenAPI documentation */
+	private readonly description?: ProcedureDescription;
 
 	/**
 	 * Built-in middleware that adds SuperJSON serialization support to the context
@@ -74,28 +105,68 @@ export class Procedure<
 		};
 
 	/**
-	 * Creates a new Procedure instance with optional middleware and schemas
+	 * Creates a new Procedure instance with optional middleware, schemas, and description
 	 *
 	 * @param middlewares - Array of middleware functions to apply, defaults to empty array
 	 * @param inputSchema - Optional Zod schema for input validation
 	 * @param incomingSchema - Optional Zod schema for incoming WebSocket message validation
 	 * @param outgoingSchema - Optional Zod schema for outgoing WebSocket message validation
+	 * @param description - Optional description metadata for OpenAPI documentation
 	 */
 	constructor(
 		middlewares: MiddlewareFunction<Ctx, void, E>[] = [],
 		inputSchema?: InputSchema,
 		incomingSchema?: Incoming,
 		outgoingSchema?: Outgoing,
+		description?: ProcedureDescription,
 	) {
 		this.middlewares = middlewares;
 		this.inputSchema = inputSchema;
 		this.incomingSchema = incomingSchema;
 		this.outgoingSchema = outgoingSchema;
+		this.description = description;
 
 		// Ensure SuperJSON middleware is always included
 		if (!this.middlewares.some((mw) => mw.name === "superjsonMiddleware")) {
 			this.middlewares.push(this.superjsonMiddleware);
 		}
+	}
+
+	/**
+	 * Sets documentation metadata for the procedure
+	 * Creates a new Procedure instance with the provided description
+	 *
+	 * @param description - Documentation metadata including description, output schema, and OpenAPI details
+	 * @returns New Procedure instance with description configured
+	 *
+	 * @example
+	 * ```typescript
+	 * const getUserProcedure = procedure
+	 *   .input(z.object({ id: z.string() }))
+	 *   .describe({
+	 *     description: "Retrieves a user by their unique identifier",
+	 *     summary: "Get user by ID",
+	 *     schema: z.object({
+	 *       id: z.string(),
+	 *       name: z.string(),
+	 *       email: z.string()
+	 *     }),
+	 *     tags: ["users"],
+	 *     operationId: "getUser"
+	 *   })
+	 *   .get(({ input, c }) => {
+	 *     // Handler implementation
+	 *   });
+	 * ```
+	 */
+	describe(description: ProcedureDescription) {
+		return new Procedure<E, Ctx, InputSchema, Incoming, Outgoing>(
+			this.middlewares,
+			this.inputSchema,
+			this.incomingSchema,
+			this.outgoingSchema,
+			description,
+		);
 	}
 
 	/**
@@ -112,6 +183,7 @@ export class Procedure<
 			this.inputSchema,
 			schema,
 			this.outgoingSchema,
+			this.description,
 		);
 	}
 
@@ -129,6 +201,7 @@ export class Procedure<
 			this.inputSchema,
 			this.incomingSchema,
 			schema,
+			this.description,
 		);
 	}
 
@@ -146,6 +219,7 @@ export class Procedure<
 			schema,
 			this.incomingSchema,
 			this.outgoingSchema,
+			this.description,
 		);
 	}
 
@@ -166,18 +240,19 @@ export class Procedure<
 			this.inputSchema,
 			this.incomingSchema,
 			this.outgoingSchema,
+			this.description,
 		);
 	}
 
 	/**
-	 * Creates a GET operation with the configured middleware and schemas
+	 * Creates a GET operation with the configured middleware, schemas, and documentation
 	 *
 	 * @template Return - Return type of the handler function
 	 * @param handler - Function to handle GET requests
 	 * @param handler.ctx - Context object accumulated from middleware
 	 * @param handler.c - Hono context with SuperJSON capabilities
 	 * @param handler.input - Validated input data based on input schema
-	 * @returns GetOperation configuration object
+	 * @returns GetOperation configuration object with description metadata
 	 */
 	get<Return extends OptionalPromise<ResponseType<any>>>(
 		handler: ({
@@ -189,7 +264,9 @@ export class Procedure<
 			c: ContextWithSuperJSON<E>;
 			input: InferZodType<InputSchema>;
 		}) => Return,
-	): GetOperation<InputSchema, ReturnType<typeof handler>, E> {
+	): GetOperation<InputSchema, ReturnType<typeof handler>, E> & {
+		description?: ProcedureDescription;
+	} {
 		return {
 			type: "get",
 			schema: this.inputSchema as
@@ -198,6 +275,7 @@ export class Procedure<
 				| void,
 			handler: handler as any,
 			middlewares: this.middlewares,
+			description: this.description,
 		};
 	}
 
@@ -207,7 +285,7 @@ export class Procedure<
 	 *
 	 * @template Return - Return type of the handler function
 	 * @param handler - Function to handle query requests
-	 * @returns GetOperation configuration object
+	 * @returns GetOperation configuration object with description metadata
 	 */
 	query<Return extends OptionalPromise<ResponseType<any>>>(
 		handler: ({
@@ -219,19 +297,21 @@ export class Procedure<
 			c: ContextWithSuperJSON<E>;
 			input: InferZodType<InputSchema>;
 		}) => Return,
-	): GetOperation<InputSchema, Return, E> {
+	): GetOperation<InputSchema, Return, E> & {
+		description?: ProcedureDescription;
+	} {
 		return this.get(handler);
 	}
 
 	/**
-	 * Creates a POST operation with the configured middleware and schemas
+	 * Creates a POST operation with the configured middleware, schemas, and documentation
 	 *
 	 * @template Return - Return type of the handler function
 	 * @param handler - Function to handle POST requests
 	 * @param handler.ctx - Context object accumulated from middleware
 	 * @param handler.c - Hono context with SuperJSON capabilities
 	 * @param handler.input - Validated input data based on input schema
-	 * @returns PostOperation configuration object
+	 * @returns PostOperation configuration object with description metadata
 	 */
 	post<Return extends OptionalPromise<ResponseType<any>>>(
 		handler: ({
@@ -243,7 +323,9 @@ export class Procedure<
 			c: ContextWithSuperJSON<E>;
 			input: InferZodType<InputSchema>;
 		}) => Return,
-	): PostOperation<InputSchema, ReturnType<typeof handler>, E> {
+	): PostOperation<InputSchema, ReturnType<typeof handler>, E> & {
+		description?: ProcedureDescription;
+	} {
 		return {
 			type: "post",
 			schema: this.inputSchema as
@@ -252,6 +334,7 @@ export class Procedure<
 				| void,
 			handler: handler as any,
 			middlewares: this.middlewares,
+			description: this.description,
 		};
 	}
 
@@ -261,7 +344,7 @@ export class Procedure<
 	 *
 	 * @template Return - Return type of the handler function
 	 * @param handler - Function to handle mutation requests
-	 * @returns PostOperation configuration object
+	 * @returns PostOperation configuration object with description metadata
 	 */
 	mutation<Return extends OptionalPromise<ResponseType<any>>>(
 		handler: ({
@@ -273,19 +356,21 @@ export class Procedure<
 			c: ContextWithSuperJSON<E>;
 			input: InferZodType<InputSchema>;
 		}) => Return,
-	): PostOperation<InputSchema, Return, E> {
+	): PostOperation<InputSchema, Return, E> & {
+		description?: ProcedureDescription;
+	} {
 		return this.post(handler);
 	}
 
 	/**
-	 * Creates a WebSocket operation with the configured middleware and schemas
+	 * Creates a WebSocket operation with the configured middleware, schemas, and documentation
 	 * Enables real-time bidirectional communication with message validation
 	 *
 	 * @param handler - Function to handle WebSocket connections
 	 * @param handler.io - IO interface for WebSocket communication with validated outgoing data
 	 * @param handler.c - Hono context with SuperJSON capabilities
 	 * @param handler.ctx - Context object accumulated from middleware
-	 * @returns WebSocketOperation configuration object with incoming/outgoing schemas
+	 * @returns WebSocketOperation configuration object with incoming/outgoing schemas and description
 	 */
 	ws(
 		handler: ({
@@ -299,12 +384,15 @@ export class Procedure<
 		}) => OptionalPromise<
 			WebSocketHandler<InferZodType<Incoming>, InferZodType<Outgoing>>
 		>,
-	): WebSocketOperation<InferZodType<Incoming>, InferZodType<Outgoing>, E> {
+	): WebSocketOperation<InferZodType<Incoming>, InferZodType<Outgoing>, E> & {
+		description?: ProcedureDescription;
+	} {
 		return {
 			type: "ws",
 			outputFormat: "ws",
 			handler: handler as any,
 			middlewares: this.middlewares,
+			description: this.description,
 		};
 	}
 }

--- a/packages/rpc/src/router.ts
+++ b/packages/rpc/src/router.ts
@@ -3,9 +3,10 @@ import { env } from "hono/adapter";
 import { HTTPException } from "hono/http-exception";
 import type { Env, ErrorHandler, MiddlewareHandler } from "hono/types";
 import type { StatusCode } from "hono/utils/http-status";
-import { ZodObject, toJSONSchema, z } from "zod/v4";
+import { ZodObject, z } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
 import { bodyParsingMiddleware, queryParsingMiddleware } from "./middleware";
+import { toJSONSchemaWithDate } from "./openapi";
 import type { ProcedureDescription } from "./procedure";
 import { IO, ServerSocket } from "./sockets";
 import { logger } from "./sockets/logger";
@@ -252,10 +253,10 @@ export class Router<
 					type: "ws",
 					schema: {
 						incoming: procData.incoming
-							? toJSONSchema(procData.incoming)
+							? toJSONSchemaWithDate(procData.incoming)
 							: null,
 						outgoing: procData.outgoing
-							? toJSONSchema(procData.outgoing)
+							? toJSONSchemaWithDate(procData.outgoing)
 							: null,
 					},
 				} satisfies WSProcedureMetadata;
@@ -263,7 +264,9 @@ export class Router<
 				// Handle GET/POST operations
 				this._metadata.procedures[procName] = {
 					type: procData.type,
-					schema: procData.schema ? toJSONSchema(procData.schema) : null,
+					schema: procData.schema
+						? toJSONSchemaWithDate(procData.schema)
+						: null,
 				} satisfies GetPostProcedureMetadata;
 			}
 		}
@@ -397,10 +400,10 @@ export class Router<
 					type: "ws",
 					schema: {
 						incoming: wsOperation.incoming
-							? toJSONSchema(wsOperation.incoming)
+							? toJSONSchemaWithDate(wsOperation.incoming)
 							: null,
 						outgoing: wsOperation.outgoing
-							? toJSONSchema(wsOperation.outgoing)
+							? toJSONSchemaWithDate(wsOperation.outgoing)
 							: null,
 					},
 				} satisfies WSProcedureMetadata;
@@ -410,7 +413,7 @@ export class Router<
 					type: operation.type, // TypeScript knows this is "get" | "post"
 					schema:
 						operation.schema instanceof ZodObject
-							? toJSONSchema(operation.schema)
+							? toJSONSchemaWithDate(operation.schema)
 							: null,
 				} satisfies GetPostProcedureMetadata;
 			}

--- a/packages/rpc/src/router.ts
+++ b/packages/rpc/src/router.ts
@@ -3,9 +3,12 @@ import { env } from "hono/adapter";
 import { HTTPException } from "hono/http-exception";
 import type { Env, ErrorHandler, MiddlewareHandler } from "hono/types";
 import type { StatusCode } from "hono/utils/http-status";
-import { z, toJSONSchema, ZodObject } from "zod/v4";
+import { ZodObject, toJSONSchema, z } from "zod/v4";
+import type { JSONSchema } from "zod/v4/core";
 import { bodyParsingMiddleware, queryParsingMiddleware } from "./middleware";
+import type { ProcedureDescription } from "./procedure";
 import { IO, ServerSocket } from "./sockets";
+import { logger } from "./sockets/logger";
 import type {
 	ContextWithSuperJSON,
 	GetOperation,
@@ -15,8 +18,6 @@ import type {
 	RouterConfig,
 	WebSocketOperation,
 } from "./types";
-import { logger } from "./sockets/logger";
-import type { JSONSchema } from "zod/v4/core";
 
 /**
  * Utility type that flattens nested route structures into a flat key-value mapping
@@ -189,6 +190,8 @@ export class Router<
 		procedures: Record<string, ProcedureMetadata>;
 		/** List of registered route paths */
 		registeredPaths: string[];
+		/** Original operations with description metadata */
+		operations: Record<string, OperationType<any, any, E>>;
 	};
 
 	/** Global error handler for the router */
@@ -227,7 +230,11 @@ export class Router<
 			config: {},
 			procedures: {},
 			registeredPaths: [],
+			operations: {},
 		};
+
+		// Store original operations for OpenAPI generation
+		this.storeOperations(procedures);
 
 		// Process procedures to extract metadata
 		for (const [procName, value] of Object.entries(procedures)) {
@@ -236,6 +243,7 @@ export class Router<
 				schema?: ZodObject;
 				incoming?: ZodObject;
 				outgoing?: ZodObject;
+				description?: ProcedureDescription;
 			};
 
 			if (procData.type === "ws") {
@@ -254,7 +262,7 @@ export class Router<
 			} else {
 				// Handle GET/POST operations
 				this._metadata.procedures[procName] = {
-					type: procData.type, // Now TypeScript knows this is "get" | "post"
+					type: procData.type,
 					schema: procData.schema ? toJSONSchema(procData.schema) : null,
 				} satisfies GetPostProcedureMetadata;
 			}
@@ -266,6 +274,44 @@ export class Router<
 		};
 
 		this.setupRoutes(procedures);
+	}
+
+	/**
+	 * Stores original operations with their description metadata
+	 * This flattens nested procedures and stores them for OpenAPI generation
+	 */
+	private storeOperations(procedures: Record<string, any>) {
+		for (const [key, value] of Object.entries(procedures)) {
+			if (this.isOperationType(value)) {
+				this._metadata.operations[key] = value;
+			} else if (typeof value === "object" && value !== null) {
+				for (const [subKey, subValue] of Object.entries(value)) {
+					if (this.isOperationType(subValue)) {
+						this._metadata.operations[`${key}/${subKey}`] = subValue;
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Gets the description metadata for a specific operation
+	 * @param operationName - Name of the operation to get description for
+	 * @returns Description metadata if available
+	 */
+	getOperationDescription(
+		operationName: string,
+	): ProcedureDescription | undefined {
+		const operation = this._metadata.operations[operationName];
+		return operation?.description;
+	}
+
+	/**
+	 * Gets all operations with their descriptions for OpenAPI generation
+	 * @returns Record of operation names to their full operation definitions
+	 */
+	getAllOperations(): Record<string, OperationType<any, any, E>> {
+		return { ...this._metadata.operations };
 	}
 
 	/**

--- a/packages/rpc/src/types.ts
+++ b/packages/rpc/src/types.ts
@@ -4,6 +4,7 @@ import type { StatusCode } from "hono/utils/http-status";
 import type superjson from "superjson";
 import type { z as zV3 } from "zod";
 import type { z as zV4 } from "zod/v4";
+import type { ProcedureDescription } from "./procedure";
 import type { IO, ServerSocket } from "./sockets";
 
 /**
@@ -162,6 +163,8 @@ export type WebSocketOperation<
 	}) => OptionalPromise<WebSocketHandler<IncomingSchema, OutgoingSchema>>;
 	/** Array of middleware functions to apply */
 	middlewares: MiddlewareFunction<any, any, E>[];
+	/** Optional description metadata for OpenAPI documentation */
+	description?: ProcedureDescription;
 };
 
 /**
@@ -218,6 +221,8 @@ export type GetOperation<
 	}) => UnwrapResponse<OptionalPromise<Return>>;
 	/** Array of middleware functions to apply */
 	middlewares: MiddlewareFunction<any, any, E>[];
+	/** Optional description metadata for OpenAPI documentation */
+	description?: ProcedureDescription;
 };
 
 /**
@@ -250,6 +255,8 @@ export type PostOperation<
 	}) => UnwrapResponse<OptionalPromise<Return>>;
 	/** Array of middleware functions to apply */
 	middlewares: MiddlewareFunction<any, any, E>[];
+	/** Optional description metadata for OpenAPI documentation */
+	description?: ProcedureDescription;
 };
 
 /**


### PR DESCRIPTION
# Pull Request

## Description

- Added a new `describe` method to the `Procedure` class for attaching OpenAPI metadata, including descriptions, summaries, tags, and operation IDs.
- Introduced `OpenAPISpec` and `OpenAPIConfig` interfaces to define the structure of the generated OpenAPI specification.
- Implemented `generateOpenAPISpec` function to create OpenAPI documentation from JSandy routers.
- Enhanced the `Router` class to store operations with their descriptions for OpenAPI generation.
- Added tests to verify the functionality of the new OpenAPI features and ensure proper integration with existing procedures.

## Type of Change

- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `docs`: Documentation changes
- [ ] `style`: Code style changes (formatting, etc.)
- [ ] `refactor`: Code refactoring (no functional changes)
- [x] `test`: Adding or updating tests
- [ ] `chore`: Maintenance tasks
- [ ] `breaking`: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Affected Packages

- [x] `@jsandy/rpc`
- [ ] `@jsandy/builder`
- [ ] `@jsandy/typescript-config`
- [ ] `create-jsandy-app`
- [x] `www`
- [ ] Root workspace/tooling

## Testing

Please describe how your changes have been tested:

- [x] Unit tests pass (`bun test`)
- [x] Type checking passes (`bun check-types`)
- [x] Linting passes (`bun lint`)
- [x] Build succeeds (`bun run build`)
- [x] Manual testing performed

### Test Coverage

- [x] New features include tests
- [x] Tests cover edge cases
- [x] All tests are passing
