### PR TITLE
Fix Pathing Bugs

### DIFF
--- a/.changeset/chilly-areas-leave.md
+++ b/.changeset/chilly-areas-leave.md
@@ -1,0 +1,5 @@
+---
+"create-jsandy-app": patch
+---
+
+Fix bug where it would import from `"jsandy"` instead of `"@jsandy/rpc"`

--- a/.changeset/twelve-regions-learn.md
+++ b/.changeset/twelve-regions-learn.md
@@ -1,0 +1,5 @@
+---
+"@jsandy/rpc": patch
+---
+
+Fix Bug Where `.$get` and `.$post` weren't callable for nested routes

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,5 +56,6 @@
 		"drizzle.config.*": "typescript"
 	},
 	"sqltools.useNodeRuntime": true,
-	"sqltools.connections": []
+	"sqltools.connections": [],
+	"cSpell.words": ["jfetch"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,5 +57,5 @@
 	},
 	"sqltools.useNodeRuntime": true,
 	"sqltools.connections": [],
-	"cSpell.words": ["jfetch"]
+	"cSpell.words": ["jfetch", "subrouters"]
 }

--- a/packages/cli/src/installers/drizzle.ts
+++ b/packages/cli/src/installers/drizzle.ts
@@ -1,5 +1,5 @@
-import fs from "fs-extra";
 import path from "node:path";
+import fs from "fs-extra";
 import type { PackageJson } from "type-fest";
 
 import { PKG_ROOT } from "@/constants";
@@ -9,10 +9,17 @@ import { addPackageDependency } from "@/utils/add-package-dep";
 export const drizzleInstaller: Installer = ({
 	projectDir,
 	databaseProvider,
+	linter,
 }) => {
+	const devDependencies: ("drizzle-kit" | "eslint-plugin-drizzle")[] = [
+		"drizzle-kit",
+	];
+	if (linter === "eslint") {
+		devDependencies.push("eslint-plugin-drizzle");
+	}
 	addPackageDependency({
 		projectDir,
-		dependencies: ["drizzle-kit", "eslint-plugin-drizzle"],
+		dependencies: devDependencies,
 		devDependencies: true,
 	});
 	addPackageDependency({

--- a/packages/cli/template/extras/src/server/jsandy/base.ts
+++ b/packages/cli/template/extras/src/server/jsandy/base.ts
@@ -1,4 +1,4 @@
-import { jsandy } from "jsandy";
+import { jsandy } from "@jsandy/rpc";
 
 interface Env {
 	// Replace with your own binding types

--- a/packages/cli/template/extras/src/server/jsandy/drizzle-with-neon.ts
+++ b/packages/cli/template/extras/src/server/jsandy/drizzle-with-neon.ts
@@ -1,7 +1,7 @@
+import { jsandy } from "@jsandy/rpc";
 import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 import { env } from "hono/adapter";
-import { jsandy } from "jsandy";
 
 interface Env {
 	Bindings: { DATABASE_URL: string };

--- a/packages/cli/template/extras/src/server/jsandy/drizzle-with-planetscale.ts
+++ b/packages/cli/template/extras/src/server/jsandy/drizzle-with-planetscale.ts
@@ -1,8 +1,8 @@
+import { jsandy } from "@jsandy/rpc";
 import { Client } from "@planetscale/database";
 import { drizzle } from "drizzle-orm/planetscale-serverless";
 import { env } from "hono/adapter";
 import { HTTPException } from "hono/http-exception";
-import { jsandy } from "jsandy";
 
 interface Env {
 	Bindings: { DATABASE_URL: string };

--- a/packages/cli/template/extras/src/server/jsandy/drizzle-with-postgres.ts
+++ b/packages/cli/template/extras/src/server/jsandy/drizzle-with-postgres.ts
@@ -1,4 +1,4 @@
-import { jsandy } from "jsandy";
+import { jsandy } from "@jsandy/rpc";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { env } from "hono/adapter";
 

--- a/packages/cli/template/extras/src/server/jsandy/drizzle-with-vercel-postgres.ts
+++ b/packages/cli/template/extras/src/server/jsandy/drizzle-with-vercel-postgres.ts
@@ -1,6 +1,6 @@
+import { jsandy } from "@jsandy/rpc";
 import { sql } from "@vercel/postgres";
 import { drizzle } from "drizzle-orm/vercel-postgres";
-import { jsandy } from "jsandy";
 
 interface Env {
 	Bindings: { POSTGRES_URL: string };

--- a/packages/rpc/src/__tests__/__mocks__/router.mock.ts
+++ b/packages/rpc/src/__tests__/__mocks__/router.mock.ts
@@ -27,10 +27,22 @@ export const chatRouter = j.router({
 // Complete app router combining all routes
 export const combinedRouter = j.router({
 	health: procedures.health,
-	user: procedures.getUser,
+	getUser: procedures.getUser,
+	getUsers: procedures.getUsers,
+	createUser: procedures.createUser,
 	profile: procedures.getProfile,
 	admin: procedures.adminOnly,
 	chat: procedures.chat,
 	files: procedures.uploadFile,
 	testing: procedures.errorExample,
+});
+
+const api = j
+	.router()
+	.basePath("/api")
+	.use(j.defaults.cors)
+	.onError(j.defaults.errorHandler);
+
+export const mockAppRouter = j.mergeRouters(api, {
+	combined: combinedRouter,
 });

--- a/packages/rpc/src/__tests__/client.test.ts
+++ b/packages/rpc/src/__tests__/client.test.ts
@@ -8,7 +8,7 @@ import {
 	spyOn,
 } from "bun:test";
 import { HTTPException } from "hono/http-exception";
-import superjson, { SuperJSON } from "superjson";
+import superjson from "superjson";
 import { createClient } from "../client";
 import type { mockAppRouter } from "./__mocks__/router.mock";
 
@@ -248,7 +248,7 @@ describe("Client", () => {
 			const queryParams = Object.fromEntries(
 				Array.from(url.searchParams.entries()).map(([key, value]) => [
 					key,
-					SuperJSON.parse<string | Date | Set<number>>(value),
+					superjson.parse<string | Date | Set<number>>(value),
 				]),
 			);
 			expect(queryParams).toEqual({

--- a/packages/rpc/src/__tests__/schema.test.ts
+++ b/packages/rpc/src/__tests__/schema.test.ts
@@ -208,7 +208,7 @@ describe("Schema", () => {
 			});
 
 			expect(typeof client.rpc.health.$get).toBe("function");
-			expect(typeof client.rpc.user.$get).toBe("function");
+			expect(typeof client.rpc.getUser.$get).toBe("function");
 			expect(typeof client.rpc.files.$post).toBe("function");
 		});
 	});

--- a/packages/rpc/src/__tests__/schema.test.ts
+++ b/packages/rpc/src/__tests__/schema.test.ts
@@ -8,13 +8,6 @@ import {
 	userRouter,
 } from "./__mocks__/router.mock";
 
-mock.module("hono/client", () => ({
-	hc: mock(() => ({
-		$get: mock(),
-		$post: mock(),
-	})),
-}));
-
 const optionalAwait = async <T>(promise: Promise<T> | T): Promise<T> =>
 	promise instanceof Promise ? await promise : promise;
 
@@ -58,15 +51,15 @@ describe("Schema", () => {
 			expect(procedures.health).toBeDefined();
 			expect(procedures.health.type).toBe("get");
 
-			expect(procedures.user).toBeDefined();
-			expect(procedures.user.type).toBe("get");
+			expect(procedures.getUser).toBeDefined();
+			expect(procedures.getUser.type).toBe("get");
 
 			expect(procedures.profile).toBeDefined();
 			expect(procedures.profile.type).toBe("get");
 
 			// Test nested procedures
-			expect(procedures.user).toBeDefined();
-			expect(procedures.user.type).toBe("get");
+			expect(procedures.getUser).toBeDefined();
+			expect(procedures.getUser.type).toBe("get");
 
 			expect(procedures.admin).toBeDefined();
 			expect(procedures.admin.type).toBe("get");
@@ -127,11 +120,11 @@ describe("Schema", () => {
 			)?._metadata.procedures;
 
 			// Test that procedures with schemas have them stored
-			expect(procedures.user.schema).toBeDefined();
-			expect(procedures.user.schema).toBeTypeOf("object");
+			expect(procedures.getUser.schema).toBeDefined();
+			expect(procedures.getUser.schema).toBeTypeOf("object");
 
-			expect(procedures.user.schema).toBeDefined();
-			expect(procedures.user.schema).toBeTypeOf("object");
+			expect(procedures.createUser.schema).toBeDefined();
+			expect(procedures.createUser.schema).toBeTypeOf("object");
 
 			// Test that procedures without schemas have null
 			expect(procedures.health.schema).toBeNull();
@@ -148,7 +141,7 @@ describe("Schema", () => {
 			)?._metadata.procedures;
 
 			// Test that complex schema (like users/create) has proper structure
-			const createUserProcedure = procedures.user;
+			const createUserProcedure = procedures.createUser;
 			expect(createUserProcedure).toBeDefined();
 
 			if (createUserProcedure.type === "post") {


### PR DESCRIPTION
# Pull Request

## Description

- Updated import statements to use "@jsandy/rpc" instead of "jsandy" across multiple files.
- Fixed a bug in the RPC client to ensure that `.$get` and `.$post` methods are callable for nested routes.
- Added new changeset files documenting these updates and fixes.

## Type of Change

- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style changes (formatting, etc.)
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Maintenance tasks
- [ ] `breaking`: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Affected Packages

- [x] `@jsandy/rpc`
- [ ] `@jsandy/builder`
- [ ] `@jsandy/typescript-config`
- [x] `create-jsandy-app`
- [ ] `www`
- [ ] Root workspace/tooling

## Testing

Please describe how your changes have been tested:

- [x] Unit tests pass (`bun test`)
- [x] Type checking passes (`bun check-types`)
- [x] Linting passes (`bun lint`)
- [x] Build succeeds (`bun run build`)
- [x] Manual testing performed