### PR TITLE
Fix input typings for client methods

### DIFF
--- a/.changeset/puny-boxes-work.md
+++ b/.changeset/puny-boxes-work.md
@@ -1,0 +1,5 @@
+---
+"@jsandy/rpc": patch
+---
+
+Fixed typing issues of client method inputs

--- a/packages/rpc/src/__tests__/client.test.ts
+++ b/packages/rpc/src/__tests__/client.test.ts
@@ -98,6 +98,8 @@ describe("Client", () => {
 			});
 
 			await client.combined.health.$get();
+			// This should not throw a type error now
+			await client.combined.getUsers.$get();
 
 			// Verify credentials were set to "include" by default
 			expect(mockFetch).toHaveBeenCalledWith(


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes an issue where the type needed to pass into a client method is based on the zod type's output instead of the zod type's possible input

## Type of Change

- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style changes (formatting, etc.)
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Maintenance tasks
- [ ] `breaking`: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Affected Packages

- [x] `@jsandy/rpc`
- [ ] `@jsandy/builder`
- [ ] `@jsandy/typescript-config`
- [ ] `create-jsandy-app`
- [ ] `www`
- [ ] Root workspace/tooling
